### PR TITLE
chunsam_BE에 있던 user 관련 entity, msa domain으로 이동

### DIFF
--- a/src/main/java/com/playus/userservice/UserServiceApplication.java
+++ b/src/main/java/com/playus/userservice/UserServiceApplication.java
@@ -1,4 +1,4 @@
-package com.playus.user_service;
+package com.playus.userservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/src/main/java/com/playus/userservice/domain/common/BaseTimeEntity.java
+++ b/src/main/java/com/playus/userservice/domain/common/BaseTimeEntity.java
@@ -1,0 +1,22 @@
+package com.playus.userservice.domain.common;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/playus/userservice/domain/report/entity/Report.java
+++ b/src/main/java/com/playus/userservice/domain/report/entity/Report.java
@@ -1,0 +1,56 @@
+package com.playus.userservice.domain.report.entity;
+
+import com.playus.userservice.domain.common.BaseTimeEntity;
+import com.playus.userservice.domain.report.enums.TargetType;
+import com.playus.userservice.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "reports")
+public class Report extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="report_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "report_user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String text;
+
+    @Column(nullable = false, name = "target_id")
+    private Long targetId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, name = "target_type")
+    private TargetType targetType;
+
+    @Builder
+    private Report(User user, String text, Long targetId, TargetType targetType) {
+        this.user = user;
+        this.text = text;
+        this.targetId = targetId;
+        this.targetType = targetType;
+    }
+
+    public static Report create(User user, String text, Long targetId, TargetType targetType) {
+        return Report.builder()
+                .user(user)
+                .text(text)
+                .targetId(targetId)
+                .targetType(targetType)
+                .build();
+    }
+
+    public void updateAll(Report report) {
+        this.text = report.getText();
+        this.targetId = report.getTargetId();
+        this.targetType = report.getTargetType();
+    }
+}

--- a/src/main/java/com/playus/userservice/domain/report/enums/TargetType.java
+++ b/src/main/java/com/playus/userservice/domain/report/enums/TargetType.java
@@ -1,0 +1,5 @@
+package com.playus.userservice.domain.report.enums;
+
+public enum TargetType {
+    POST, COMMENT, USER, CHAT
+}

--- a/src/main/java/com/playus/userservice/domain/user/entity/Notification.java
+++ b/src/main/java/com/playus/userservice/domain/user/entity/Notification.java
@@ -1,0 +1,55 @@
+package com.playus.userservice.domain.user.entity;
+
+import com.playus.userservice.domain.common.BaseTimeEntity;
+import com.playus.userservice.domain.user.enums.Type;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "notifications")
+public class Notification extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "notification_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "receiver_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false, length = 255)
+    private String message;
+
+    @Column(nullable = false, name = "is_read")
+    private boolean isRead;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Type type;
+
+    @Builder
+    private Notification(User user, String message, boolean isRead, Type type) {
+        this.user = user;
+        this.message = message;
+        this.isRead = isRead;
+        this.type = type;
+    }
+
+    public static Notification create(User user, String message, Type type) {
+        return Notification.builder()
+                .user(user)
+                .message(message)
+                .isRead(false)
+                .type(type)
+                .build();
+    }
+
+    public void updateAll(Notification notification) {
+        this.message = notification.getMessage();
+        this.isRead = notification.isRead();
+        this.type = notification.getType();
+    }
+}

--- a/src/main/java/com/playus/userservice/domain/user/entity/Tag.java
+++ b/src/main/java/com/playus/userservice/domain/user/entity/Tag.java
@@ -1,0 +1,30 @@
+package com.playus.userservice.domain.user.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "tag")
+public class Tag {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "tag_id")
+    private Long id;
+
+    @Column(nullable = false, name = "tag_name", length = 255)
+    private String tagName;
+
+    @Builder
+    private Tag(String tagName){
+        this.tagName = tagName;
+    }
+
+    public static Tag create(String tagName){
+        return Tag.builder()
+                .tagName(tagName)
+                .build();
+    }
+}

--- a/src/main/java/com/playus/userservice/domain/user/entity/User.java
+++ b/src/main/java/com/playus/userservice/domain/user/entity/User.java
@@ -1,0 +1,92 @@
+package com.playus.userservice.domain.user.entity;
+
+import com.playus.userservice.domain.common.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import com.playus.userservice.domain.user.enums.Role;
+import com.playus.userservice.domain.user.enums.Gender;
+import com.playus.userservice.domain.user.enums.AuthProvider;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "users")
+public class User extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long id;
+
+    @Column(nullable = false, length = 255)
+    private String nickname;
+
+    @Column(nullable = false)
+    private LocalDate birth;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Gender gender;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private AuthProvider authProvider;
+
+    @Column(nullable = true)
+    private boolean activated;
+
+    @Column(name = "thumbnail_url", length = 255, nullable = false)
+    private String thumbnailURL;
+
+    @Column(name = "user_score", nullable = false)
+    private Float userScore;
+
+    private LocalDateTime blockOff;
+
+    @Builder
+    private User(String nickname, LocalDate birth, Gender gender, Role role, AuthProvider authProvider, boolean activated, LocalDateTime blockOff, String thumbnailURL, Float userScore) {
+        this.nickname = nickname;
+        this.birth = birth;
+        this.gender = gender;
+        this.role = role;
+        this.authProvider = authProvider;
+        this.activated = activated;
+        this.blockOff = blockOff;
+        this.thumbnailURL = thumbnailURL;
+        this.userScore = userScore;
+    }
+
+    public static User create(String nickname, LocalDate birth, Gender gender, Role role, AuthProvider authProvider, String thumbnailURL, Float userScore) {
+        return User.builder()
+                .nickname(nickname)
+                .birth(birth)
+                .gender(gender)
+                .role(role)
+                .authProvider(authProvider)
+                .activated(true)
+                .blockOff(null)
+                .thumbnailURL(thumbnailURL)
+                .userScore(0.3f)
+                .build();
+    }
+
+    public void updateBlockOff(LocalDateTime blockOff) {
+        this.blockOff = blockOff;
+    }
+    public void updateImage(String thumbnailURL) {this.thumbnailURL = thumbnailURL; }
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public void withdrawAccount() {
+        this.activated = false;
+    }
+
+}

--- a/src/main/java/com/playus/userservice/domain/user/entity/UserTag.java
+++ b/src/main/java/com/playus/userservice/domain/user/entity/UserTag.java
@@ -1,0 +1,38 @@
+package com.playus.userservice.domain.user.entity;
+
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "user_tag")
+public class UserTag {
+
+    @Id@GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_tag_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false, name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "tag_id", nullable = false)
+    private Tag tag;
+
+    @Builder
+    private UserTag(User user, Tag tag) {
+        this.user = user;
+        this.tag = tag;
+    }
+
+    public static UserTag create(User user, Tag tag){
+        return UserTag.builder()
+                .user(user)
+                .tag(tag)
+                .build();
+    }
+
+}

--- a/src/main/java/com/playus/userservice/domain/user/enums/AuthProvider.java
+++ b/src/main/java/com/playus/userservice/domain/user/enums/AuthProvider.java
@@ -1,0 +1,5 @@
+package com.playus.userservice.domain.user.enums;
+
+public enum AuthProvider {
+    KAKAO, NAVER, GOOGLE
+}

--- a/src/main/java/com/playus/userservice/domain/user/enums/Gender.java
+++ b/src/main/java/com/playus/userservice/domain/user/enums/Gender.java
@@ -1,0 +1,5 @@
+package com.playus.userservice.domain.user.enums;
+
+public enum Gender {
+    MALE, FEMALE
+}

--- a/src/main/java/com/playus/userservice/domain/user/enums/Role.java
+++ b/src/main/java/com/playus/userservice/domain/user/enums/Role.java
@@ -1,0 +1,5 @@
+package com.playus.userservice.domain.user.enums;
+
+public enum Role {
+    USER, ADMIN
+}

--- a/src/main/java/com/playus/userservice/domain/user/enums/Type.java
+++ b/src/main/java/com/playus/userservice/domain/user/enums/Type.java
@@ -1,0 +1,5 @@
+package com.playus.userservice.domain.user.enums;
+
+public enum Type {
+    INVITION
+}

--- a/src/main/java/com/playus/userservice/global/swagger/SwaggerConfig.java
+++ b/src/main/java/com/playus/userservice/global/swagger/SwaggerConfig.java
@@ -1,4 +1,4 @@
-package com.playus.user_service.global.swagger;
+package com.playus.userservice.global.swagger;
 
 import java.util.List;
 

--- a/src/test/java/com/playus/userservice/UserServiceApplicationTests.java
+++ b/src/test/java/com/playus/userservice/UserServiceApplicationTests.java
@@ -1,4 +1,4 @@
-package com.playus.user_service;
+package com.playus.userservice;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;


### PR DESCRIPTION
외래키연결 끊고 Long id로 사용

## ✅ PR 유형
어떤 변경 사항이 있었나요?

- ✅ 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용

패키지명
package com.playus.user_service; 에서
package com.playus.userservice; 로 변경했습니다.

외부 DB 대한 FK (ex) User 테이블)는 우선 외부 테이블의 ID를 참조하는 방식으로 작성했습니다.

관련 https://ksh-coding.tistory.com/140#0.%20%EB%AA%A8%EB%86%80%EB%A6%AC%EC%8B%9D%20%EA%B5%AC%EC%A1%B0%EC%97%90%EC%84%9C%EC%9D%98%20JPA%20Entity%20%EC%97%B0%EA%B4%80%EA%B4%80%EA%B3%84%20%26%20%ED%94%84%EB%A1%9C%EC%A0%9D%ED%8A%B8%20%EB%B9%84%EC%A6%88%EB%8B%88%EC%8A%A4%20%EB%A1%9C%EC%A7%81-1


MySQL 위한 entity 입니다. 기존 BE repo의 코드를 참고했습니다.

![스크린샷 2025-04-27 140249](https://github.com/user-attachments/assets/58b44b97-f2cb-4d06-8530-8b0c24e772c2)



domain 내의
common 폴더 경로를 아래 사진 처럼 지정했는데
이렇게 유지하면 될지 피드백 부탁드립니다.

![image](https://github.com/user-attachments/assets/53a189b7-dc5f-40ac-9939-b5217fcafafa)


---

## 🔗 관련 이슈
- closes #4 

---

## 💡 추가 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 사용자, 태그, 사용자-태그 연결, 알림, 신고 엔터티 및 관련 enum이 추가되었습니다. 
    - 각 엔터티는 생성/수정 시각 자동 관리, 빌더 및 팩토리 메서드, 주요 필드 업데이트 메서드를 제공합니다.

- **리팩터**
    - 일부 파일의 패키지 선언이 일관성 있게 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->