### PR TITLE
chore/Eureka client 의존성 제거

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,9 +40,6 @@ dependencies {
 	implementation 'mysql:mysql-connector-java:8.0.33'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
-	// MSA
-	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
-
 	// Monitoring
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용

![image](https://github.com/user-attachments/assets/101965e0-b8ee-455d-b05b-78dd47dc4e21)

---

## 🔗 관련 이슈
- closes #12 

---

## 💡 추가 사항
Chores
더 이상 사용되지 않는 spring-cloud-starter-netflix-eureka-client 의존성이 제거되었습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Spring Cloud Netflix Eureka 클라이언트 의존성이 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->