### PR TITLE
Cs 218 chore/jira 이슈 생성 시 task로 변경

### DIFF
--- a/.github/ISSUE_TEMPLATE/fix-issue-form.yml
+++ b/.github/ISSUE_TEMPLATE/fix-issue-form.yml
@@ -15,8 +15,8 @@ body:
   - type : input
     id : parentKey
     attributes:
-      label: '상위 작업 (Story, 초록색 책갈피) Ticket Number'
-      description: '상위 직업 (Story, 초록색 아이콘) 의 Ticket Number를 기입해주세요, 노션에서도 확인 가능'
+      label: '상위 작업 (Epic, 보라색 번개) Ticket Number'
+      description: '상위 직업 (Epic, 보라색 아이콘) 의 Ticket Number를 기입해주세요, 노션에서도 확인 가능'
       value: CS-00
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/performance-issue-form.yml
+++ b/.github/ISSUE_TEMPLATE/performance-issue-form.yml
@@ -15,8 +15,8 @@ body:
   - type : input
     id : parentKey
     attributes:
-      label: '상위 작업 (Story, 초록색 책갈피) Ticket Number'
-      description: '상위 직업 (Story, 초록색 아이콘) 의 Ticket Number를 기입해주세요, 노션에서도 확인 가능'
+      label: '상위 작업 (Epic, 보라색 번개) Ticket Number'
+      description: '상위 직업 (Epic, 보라색 아이콘) 의 Ticket Number를 기입해주세요, 노션에서도 확인 가능'
       value: CS-00
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/refactor-issue-form.yml
+++ b/.github/ISSUE_TEMPLATE/refactor-issue-form.yml
@@ -15,8 +15,8 @@ body:
   - type : input
     id : parentKey
     attributes:
-      label: '상위 작업 (Story, 초록색 책갈피) Ticket Number'
-      description: '상위 직업 (Story, 초록색 아이콘) 의 Ticket Number를 기입해주세요, 노션에서도 확인 가능'
+      label: '상위 작업 (Epic, 보라색 번개) Ticket Number'
+      description: '상위 직업 (Epic, 보라색 아이콘) 의 Ticket Number를 기입해주세요, 노션에서도 확인 가능'
       value: CS-00
     validations:
       required: true

--- a/.github/workflows/create-jira-chore-issue.yml
+++ b/.github/workflows/create-jira-chore-issue.yml
@@ -48,7 +48,7 @@ jobs:
         uses: atlassian/gajira-create@v3
         with:
           project: CS # JIRA KEY
-          issuetype: 스토리
+          issuetype: Task
           summary: "${{ github.event.issue.title }}"
           description: "${{ steps.md2jira.outputs.output-text }}"
           fields: |

--- a/.github/workflows/create-jira-feat-issue.yml
+++ b/.github/workflows/create-jira-feat-issue.yml
@@ -48,7 +48,7 @@ jobs:
         uses: atlassian/gajira-create@v3
         with:
           project: CS # JIRA KEY
-          issuetype: 스토리
+          issuetype: Task
           summary: "${{ github.event.issue.title }}"
           description: "${{ steps.md2jira.outputs.output-text }}"
           fields: |

--- a/.github/workflows/create-jira-fix-issue.yml
+++ b/.github/workflows/create-jira-fix-issue.yml
@@ -48,7 +48,7 @@ jobs:
         uses: atlassian/gajira-create@v3
         with:
           project: CS # JIRA KEY
-          issuetype: 하위 작업 # Task, Subtask 아님!
+          issuetype: Task
           summary: "${{ github.event.issue.title }}"
           description: "${{ steps.md2jira.outputs.output-text }}"
           fields: |

--- a/.github/workflows/create-jira-performance-issue.yml
+++ b/.github/workflows/create-jira-performance-issue.yml
@@ -48,7 +48,7 @@ jobs:
         uses: atlassian/gajira-create@v3
         with:
           project: CS # JIRA KEY
-          issuetype: 하위 작업 # Task, Subtask 아님!
+          issuetype: Task
           summary: "${{ github.event.issue.title }}"
           description: "${{ steps.md2jira.outputs.output-text }}"
           fields: |

--- a/.github/workflows/create-jira-refactor-issue.yml
+++ b/.github/workflows/create-jira-refactor-issue.yml
@@ -48,7 +48,7 @@ jobs:
         uses: atlassian/gajira-create@v3
         with:
           project: CS # JIRA KEY
-          issuetype: 하위 작업 # Task, Subtask 아님!
+          issuetype: Task
           summary: "${{ github.event.issue.title }}"
           description: "${{ steps.md2jira.outputs.output-text }}"
           fields: |


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
task 생성되도록 변경

---

## 🔗 관련 이슈
- closes #24 

---

## 💡 추가 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **문서**
    - 이슈 템플릿에서 부모 작업 유형을 "스토리"에서 "에픽"으로 변경하고, 관련 아이콘과 설명을 업데이트했습니다.
- **잡무**
    - Jira 이슈 생성 워크플로우에서 이슈 유형을 한글 또는 비표준 용어(스토리, 하위 작업)에서 영어 "Task"로 통일했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->