### PR TITLE
Cs 276 feat/사용자 정보 조회

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,6 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-	implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
 
 	// DB
 	//implementation 'org.springframework.boot:spring-boot-starter-data-r2dbc'

--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'io.micrometer:micrometer-registry-prometheus'
 
+	// Object Storage
+	implementation 'software.amazon.awssdk:s3:2.20.45'
+
 	// Lombok
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/playus/userservice/domain/oauth/handler/CustomSuccessHandler.java
+++ b/src/main/java/com/playus/userservice/domain/oauth/handler/CustomSuccessHandler.java
@@ -5,6 +5,7 @@ import com.playus.userservice.domain.oauth.dto.CustomOAuth2User;
 import com.playus.userservice.domain.user.repository.write.FavoriteTeamRepository;
 import com.playus.userservice.global.jwt.JwtUtil;
 
+import com.playus.userservice.global.util.AgeUtils;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +19,7 @@ import org.springframework.security.web.authentication.SimpleUrlAuthenticationSu
 import org.springframework.stereotype.Component;
 import java.io.IOException;
 import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 
@@ -46,6 +48,9 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
             CustomOAuth2User customUser = (CustomOAuth2User) authentication.getPrincipal();
             String userId = customUser.getUserDto().getId().toString();
             String role   = authentication.getAuthorities().iterator().next().getAuthority();
+            String gender         = customUser.getUserDto().getGender().name();
+            LocalDateTime bdt     = customUser.getUserDto().getBirth().atStartOfDay();
+            int age          = AgeUtils.calculateAgeGroup(bdt);
 
             Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
             if (authorities == null || authorities.isEmpty()) {
@@ -55,7 +60,7 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
             }
 
             // Access/Refresh 토큰 생성
-            String accessToken  = jwtUtil.createAccessToken(userId, role);
+            String accessToken  = jwtUtil.createAccessToken(userId, role, age, gender );
             String refreshToken = jwtUtil.createRefreshToken(userId, role);
 
             // Redis에 Refresh Token 저장 (key = refresh:{userId})

--- a/src/main/java/com/playus/userservice/domain/oauth/service/AuthService.java
+++ b/src/main/java/com/playus/userservice/domain/oauth/service/AuthService.java
@@ -11,6 +11,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 import org.springframework.http.HttpStatus;
@@ -76,6 +78,16 @@ public class AuthService {
                 redisTemplate.opsForValue().set("blacklist:" + jti, "", Duration.ofSeconds(ttlSeconds));
             }
         }
+        // 클라이언트 쿠키(Access) 만료 처리
+        ResponseCookie expiredAccess = ResponseCookie.from("Access", "")
+                .httpOnly(true)
+                .secure(false)   // 운영환경에선 true 로 변경
+                .path("/")
+                .maxAge(0)
+                .sameSite("Lax")
+                .build();
+        res.addHeader(HttpHeaders.SET_COOKIE, expiredAccess.toString());
+
     }
 
     private boolean isExpired(String token) {

--- a/src/main/java/com/playus/userservice/domain/oauth/service/AuthService.java
+++ b/src/main/java/com/playus/userservice/domain/oauth/service/AuthService.java
@@ -3,6 +3,7 @@ package com.playus.userservice.domain.oauth.service;
 import com.playus.userservice.domain.oauth.dto.CustomOAuth2User;
 import com.playus.userservice.domain.oauth.enums.TokenType;
 import com.playus.userservice.domain.user.dto.UserDto;
+import com.playus.userservice.domain.user.enums.Gender;
 import com.playus.userservice.domain.user.enums.Role;
 import com.playus.userservice.global.jwt.JwtUtil;
 import io.jsonwebtoken.JwtException;
@@ -107,10 +108,12 @@ public class AuthService {
 
         String userId = jwtUtil.getUserId(token);
         String role = jwtUtil.getRole(token);
+        int age = jwtUtil.getAge(token);
+        String gender = jwtUtil.getGender(token);
 
         CustomOAuth2User principal =
                 new CustomOAuth2User(
-                        UserDto.fromJwt(Long.parseLong(userId), Role.valueOf(role))
+                        UserDto.fromJwt(Long.parseLong(userId), Role.valueOf(role), age, Gender.valueOf(gender))
                 );
 
         Authentication auth = new UsernamePasswordAuthenticationToken(

--- a/src/main/java/com/playus/userservice/domain/oauth/service/TokenService.java
+++ b/src/main/java/com/playus/userservice/domain/oauth/service/TokenService.java
@@ -53,7 +53,7 @@ public class TokenService {
         // 2) Redis 검증
         String userId = jwtUtil.getUserId(refresh);
         String role   = jwtUtil.getRole(refresh);
-        User user = userRepository.findById(Long.parseLong(userId))
+        User user = userRepository.findByIdAndActivatedTrue(Long.parseLong(userId))
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "USER_NOT_FOUND"));
 
         LocalDateTime bdt = user.getBirth().atStartOfDay();

--- a/src/main/java/com/playus/userservice/domain/oauth/service/TokenService.java
+++ b/src/main/java/com/playus/userservice/domain/oauth/service/TokenService.java
@@ -1,7 +1,10 @@
 package com.playus.userservice.domain.oauth.service;
 
 import com.playus.userservice.domain.oauth.enums.TokenType;
+import com.playus.userservice.domain.user.entity.User;
+import com.playus.userservice.domain.user.repository.write.UserRepository;
 import com.playus.userservice.global.jwt.JwtUtil;
+import com.playus.userservice.global.util.AgeUtils;
 import io.jsonwebtoken.JwtException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
@@ -14,6 +17,7 @@ import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.time.LocalDateTime;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
@@ -23,6 +27,7 @@ public class TokenService {
 
     private final JwtUtil jwtUtil;
     private final RedisTemplate<String, String> redisTemplate;
+    private final UserRepository userRepository;
 
     private static final String ACCESS_COOKIE  = "Access";
     private static final String REFRESH_COOKIE  = "Refresh";
@@ -48,9 +53,15 @@ public class TokenService {
         // 2) Redis 검증
         String userId = jwtUtil.getUserId(refresh);
         String role   = jwtUtil.getRole(refresh);
+        User user = userRepository.findById(Long.parseLong(userId))
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "USER_NOT_FOUND"));
+
+        LocalDateTime bdt = user.getBirth().atStartOfDay();
+        int age = AgeUtils.calculateAgeGroup(bdt);
+        String gender = user.getGender().name();
 
         // 3) 새 Access 토큰 발급
-        String newAccessToken = jwtUtil.createAccessToken(userId, role);
+        String newAccessToken = jwtUtil.createAccessToken(userId, role, age, gender);
 
         // 4) Access 토큰을 HttpOnly 쿠키로 설정
         ResponseCookie accessCookie = ResponseCookie.from("Access", newAccessToken)

--- a/src/main/java/com/playus/userservice/domain/user/controller/ProfileSetupController.java
+++ b/src/main/java/com/playus/userservice/domain/user/controller/ProfileSetupController.java
@@ -1,6 +1,8 @@
 package com.playus.userservice.domain.user.controller;
 
 import com.playus.userservice.domain.oauth.dto.CustomOAuth2User;
+import com.playus.userservice.domain.user.dto.presigned.PresignedUrlForSaveImageRequest;
+import com.playus.userservice.domain.user.dto.presigned.PresignedUrlForSaveImageResponse;
 import com.playus.userservice.domain.user.dto.profilesetup.UserRegisterRequest;
 import com.playus.userservice.domain.user.dto.profilesetup.UserRegisterResponse;
 import com.playus.userservice.domain.user.service.ProfileSetupService;
@@ -28,8 +30,17 @@ public class ProfileSetupController implements ProfileSetupControllerSpecificati
         UserRegisterResponse resp = setupService.setupProfile(
                 userId,
                 request.teamId(),
-                request.nickname()
+                request.nickname(),
+                request.thumbnailURL()
         );
         return ResponseEntity.ok(resp);
     }
+
+    @PostMapping("/presigned-url")
+    public PresignedUrlForSaveImageResponse generatePresignedUrlForSaveImage(
+            @Valid @RequestBody PresignedUrlForSaveImageRequest request) {
+
+        return setupService.generatePresignedUrlForSaveImage(request);
+    }
 }
+

--- a/src/main/java/com/playus/userservice/domain/user/controller/UserController.java
+++ b/src/main/java/com/playus/userservice/domain/user/controller/UserController.java
@@ -1,8 +1,11 @@
 package com.playus.userservice.domain.user.controller;
 
+import com.playus.userservice.domain.user.dto.UserWithdrawResponse;
 import com.playus.userservice.domain.user.dto.nickname.NicknameRequest;
 import com.playus.userservice.domain.user.dto.nickname.NicknameResponse;
 import com.playus.userservice.domain.user.specification.UserControllerSpecification;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -31,4 +34,14 @@ public class UserController implements UserControllerSpecification {
         return ResponseEntity.ok(resp);
     }
 
+    @PatchMapping("/withdraw")
+    public ResponseEntity<UserWithdrawResponse> withdraw(
+            @AuthenticationPrincipal CustomOAuth2User principal,
+            HttpServletRequest request,
+            HttpServletResponse response) {
+
+        Long userId = Long.parseLong(principal.getName());
+        UserWithdrawResponse resp = userService.withdraw(userId, request, response);
+        return ResponseEntity.ok(resp);
+    }
 }

--- a/src/main/java/com/playus/userservice/domain/user/controller/UserProfileController.java
+++ b/src/main/java/com/playus/userservice/domain/user/controller/UserProfileController.java
@@ -1,0 +1,48 @@
+package com.playus.userservice.domain.user.controller;
+
+import com.playus.userservice.domain.oauth.dto.CustomOAuth2User;
+import com.playus.userservice.domain.user.dto.profile.UserProfileResponse;
+import com.playus.userservice.domain.user.service.UserProfileReadService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/user")
+public class UserProfileController {
+
+    private final UserProfileReadService userProfileReadService;
+
+    @GetMapping("/profile")
+    public ResponseEntity<UserProfileResponse> getProfile(
+            @AuthenticationPrincipal CustomOAuth2User principal) {
+
+        Long userId = Long.parseLong(principal.getName());
+        UserProfileResponse response = userProfileReadService.getProfile(userId);
+        return ResponseEntity.ok(response);
+    }
+}
+
+/**
+ {
+ "id":18,
+ "nickname":"default_nickname",
+ "phoneNumber":"+821079070479",
+ "birth":"2000-04-26",
+ "gender":"MALE",
+ "role":"USER",
+ "authProvider":"NAVER",
+ "activated":true,
+ "thumbnailURL":"default.png",
+ "userScore":0.3,
+ "blockOff":null,
+ "favoriteTeams":[
+ {"teamId":8,"displayOrder":1},
+ {"teamId":1,"displayOrder":2}
+ ]
+ }
+ */

--- a/src/main/java/com/playus/userservice/domain/user/controller/UserProfileController.java
+++ b/src/main/java/com/playus/userservice/domain/user/controller/UserProfileController.java
@@ -26,24 +26,5 @@ public class UserProfileController implements UserProfileControllerSpecification
         UserProfileResponse response = userProfileReadService.getProfile(userId);
         return ResponseEntity.ok(response);
     }
-}
 
-/**
- {
- "id":18,
- "nickname":"default_nickname",
- "phoneNumber":"+821079070479",
- "birth":"2000-04-26",
- "gender":"MALE",
- "role":"USER",
- "authProvider":"NAVER",
- "activated":true,
- "thumbnailURL":"default.png",
- "userScore":0.3,
- "blockOff":null,
- "favoriteTeams":[
- {"teamId":8,"displayOrder":1},
- {"teamId":1,"displayOrder":2}
- ]
- }
- */
+}

--- a/src/main/java/com/playus/userservice/domain/user/controller/UserProfileController.java
+++ b/src/main/java/com/playus/userservice/domain/user/controller/UserProfileController.java
@@ -3,6 +3,7 @@ package com.playus.userservice.domain.user.controller;
 import com.playus.userservice.domain.oauth.dto.CustomOAuth2User;
 import com.playus.userservice.domain.user.dto.profile.UserProfileResponse;
 import com.playus.userservice.domain.user.service.UserProfileReadService;
+import com.playus.userservice.domain.user.specification.UserProfileControllerSpecification;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -13,7 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/user")
-public class UserProfileController {
+public class UserProfileController implements UserProfileControllerSpecification {
 
     private final UserProfileReadService userProfileReadService;
 

--- a/src/main/java/com/playus/userservice/domain/user/document/FavoriteTeamDocument.java
+++ b/src/main/java/com/playus/userservice/domain/user/document/FavoriteTeamDocument.java
@@ -1,0 +1,47 @@
+package com.playus.userservice.domain.user.document;
+
+import com.playus.userservice.domain.common.BaseTimeEntity;
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+import jakarta.validation.constraints.NotNull;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Document(collection = "favorite_team")
+public class FavoriteTeamDocument extends BaseTimeEntity {
+
+    @Id
+    private Long id;
+
+    @NotNull
+    @Field("user_id")
+    private Long userId;
+
+    @NotNull
+    @Field("team_id")
+    private Long teamId;
+
+    @NotNull
+    @Field("display_order")
+    private Integer displayOrder;
+
+    @Builder
+    private FavoriteTeamDocument(Long id, Long userId, Long teamId, Integer displayOrder) {
+        this.id = id;
+        this.userId = userId;
+        this.teamId = teamId;
+        this.displayOrder = displayOrder;
+    }
+
+    public static FavoriteTeamDocument createFavoriteTeamDocument(Long id, Long userId, Long teamId, Integer displayOrder
+    ) {
+        return FavoriteTeamDocument.builder()
+                .id(id)
+                .userId(userId)
+                .teamId(teamId)
+                .displayOrder(displayOrder)
+                .build();
+    }
+}

--- a/src/main/java/com/playus/userservice/domain/user/dto/UserDto.java
+++ b/src/main/java/com/playus/userservice/domain/user/dto/UserDto.java
@@ -25,6 +25,7 @@ public class UserDto {
     private Float userScore;
     private LocalDateTime blockOff;
     private LocalDateTime createdAt;
+    private int age;
 
     public UserDto(User user) {
         this.id = user.getId();
@@ -41,10 +42,12 @@ public class UserDto {
     }
 
     //JWT필터에서 사용
-    public static UserDto fromJwt(Long id, Role role) {
+    public static UserDto fromJwt(Long id, Role role, int age ,Gender gender) {
         UserDto dto = new UserDto();
         dto.id = id;
         dto.role = role;
+        dto.age = age;
+        dto.gender = gender;
         return dto;
     }
 }

--- a/src/main/java/com/playus/userservice/domain/user/dto/UserWithdrawResponse.java
+++ b/src/main/java/com/playus/userservice/domain/user/dto/UserWithdrawResponse.java
@@ -1,0 +1,3 @@
+package com.playus.userservice.domain.user.dto;
+
+public record UserWithdrawResponse(boolean success, String message) { }

--- a/src/main/java/com/playus/userservice/domain/user/dto/presigned/PresignedUrlForSaveImageRequest.java
+++ b/src/main/java/com/playus/userservice/domain/user/dto/presigned/PresignedUrlForSaveImageRequest.java
@@ -1,0 +1,10 @@
+package com.playus.userservice.domain.user.dto.presigned;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record PresignedUrlForSaveImageRequest (
+        @NotBlank(message = "이미지 파일명은 필수입니다!")
+        String imageFileName
+) {
+
+}

--- a/src/main/java/com/playus/userservice/domain/user/dto/presigned/PresignedUrlForSaveImageResponse.java
+++ b/src/main/java/com/playus/userservice/domain/user/dto/presigned/PresignedUrlForSaveImageResponse.java
@@ -1,0 +1,6 @@
+package com.playus.userservice.domain.user.dto.presigned;
+
+
+public record PresignedUrlForSaveImageResponse(
+        String presignedUrl
+) { }

--- a/src/main/java/com/playus/userservice/domain/user/dto/profile/FavoriteTeamDto.java
+++ b/src/main/java/com/playus/userservice/domain/user/dto/profile/FavoriteTeamDto.java
@@ -1,0 +1,10 @@
+package com.playus.userservice.domain.user.dto.profile;
+
+import lombok.Builder;
+
+@Builder
+public record FavoriteTeamDto(
+        Long teamId,
+        Integer displayOrder
+) {
+}

--- a/src/main/java/com/playus/userservice/domain/user/dto/profile/UserProfileResponse.java
+++ b/src/main/java/com/playus/userservice/domain/user/dto/profile/UserProfileResponse.java
@@ -1,0 +1,25 @@
+package com.playus.userservice.domain.user.dto.profile;
+
+import com.playus.userservice.domain.user.enums.*;
+import lombok.Builder;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Builder
+public record UserProfileResponse(
+        Long id,
+        String nickname,
+        String phoneNumber,
+        LocalDate birth,
+        Gender gender,
+        Role role,
+        AuthProvider authProvider,
+        boolean activated,
+        String thumbnailURL,
+        Float userScore,
+        LocalDateTime blockOff,
+        List<FavoriteTeamDto> favoriteTeams
+) {
+}

--- a/src/main/java/com/playus/userservice/domain/user/dto/profilesetup/UserRegisterRequest.java
+++ b/src/main/java/com/playus/userservice/domain/user/dto/profilesetup/UserRegisterRequest.java
@@ -7,5 +7,8 @@ public record UserRegisterRequest(
         Long teamId,
 
         @NotBlank(message = "nickname 필드는 필수입니다.")
-        String nickname
+        String nickname,
+
+        @NotBlank(message = "thumbnailURL 필드는 필수입니다.")
+        String thumbnailURL
 ) {}

--- a/src/main/java/com/playus/userservice/domain/user/entity/FavoriteTeam.java
+++ b/src/main/java/com/playus/userservice/domain/user/entity/FavoriteTeam.java
@@ -3,14 +3,10 @@ package com.playus.userservice.domain.user.entity;
 import com.playus.userservice.domain.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.Where;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@SQLDelete(sql = "UPDATE favorite_team SET activated = false WHERE id = ?")
-@Where(clause = "activated = true")
 @Table(name = "favorite_team",
         uniqueConstraints = @UniqueConstraint(name = "uk_user_display_order", columnNames = {"user_id", "display_order"}))
 public class FavoriteTeam extends BaseTimeEntity {

--- a/src/main/java/com/playus/userservice/domain/user/entity/FavoriteTeam.java
+++ b/src/main/java/com/playus/userservice/domain/user/entity/FavoriteTeam.java
@@ -4,13 +4,15 @@ import com.playus.userservice.domain.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE favorite_team SET activated = false WHERE id = ?")
+@Where(clause = "activated = true")
 @Table(name = "favorite_team",
         uniqueConstraints = @UniqueConstraint(name = "uk_user_display_order", columnNames = {"user_id", "display_order"}))
-@SQLDelete(sql = "UPDATE favorite_team SET activated = false WHERE id = ?")
 public class FavoriteTeam extends BaseTimeEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/playus/userservice/domain/user/entity/FavoriteTeam.java
+++ b/src/main/java/com/playus/userservice/domain/user/entity/FavoriteTeam.java
@@ -3,12 +3,14 @@ package com.playus.userservice.domain.user.entity;
 import com.playus.userservice.domain.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "favorite_team",
         uniqueConstraints = @UniqueConstraint(name = "uk_user_display_order", columnNames = {"user_id", "display_order"}))
+@SQLDelete(sql = "UPDATE favorite_team SET activated = false WHERE id = ?")
 public class FavoriteTeam extends BaseTimeEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/playus/userservice/domain/user/entity/Notification.java
+++ b/src/main/java/com/playus/userservice/domain/user/entity/Notification.java
@@ -5,12 +5,14 @@ import com.playus.userservice.domain.user.enums.Type;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "notifications")
 @SQLDelete(sql = "UPDATE notifications SET activated = false WHERE id = ?")
+@Where(clause = "activated = true")
+@Table(name = "notifications")
 public class Notification extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/com/playus/userservice/domain/user/entity/Notification.java
+++ b/src/main/java/com/playus/userservice/domain/user/entity/Notification.java
@@ -4,11 +4,13 @@ import com.playus.userservice.domain.common.BaseTimeEntity;
 import com.playus.userservice.domain.user.enums.Type;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "notifications")
+@SQLDelete(sql = "UPDATE notifications SET activated = false WHERE id = ?")
 public class Notification extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/com/playus/userservice/domain/user/entity/Notification.java
+++ b/src/main/java/com/playus/userservice/domain/user/entity/Notification.java
@@ -4,14 +4,10 @@ import com.playus.userservice.domain.common.BaseTimeEntity;
 import com.playus.userservice.domain.user.enums.Type;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.Where;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@SQLDelete(sql = "UPDATE notifications SET activated = false WHERE id = ?")
-@Where(clause = "activated = true")
 @Table(name = "notifications")
 public class Notification extends BaseTimeEntity {
 

--- a/src/main/java/com/playus/userservice/domain/user/entity/Tag.java
+++ b/src/main/java/com/playus/userservice/domain/user/entity/Tag.java
@@ -3,14 +3,10 @@ package com.playus.userservice.domain.user.entity;
 import com.playus.userservice.domain.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.Where;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@SQLDelete(sql = "UPDATE tag SET activated = false WHERE id = ?")
-@Where(clause = "activated = true")
 @Table(name = "tag", uniqueConstraints = {
         @UniqueConstraint(columnNames = "tag_name", name = "uk_tag_name")
 })

--- a/src/main/java/com/playus/userservice/domain/user/entity/Tag.java
+++ b/src/main/java/com/playus/userservice/domain/user/entity/Tag.java
@@ -4,14 +4,16 @@ import com.playus.userservice.domain.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE tag SET activated = false WHERE id = ?")
+@Where(clause = "activated = true")
 @Table(name = "tag", uniqueConstraints = {
         @UniqueConstraint(columnNames = "tag_name", name = "uk_tag_name")
 })
-@SQLDelete(sql = "UPDATE tag SET activated = false WHERE id = ?")
 public class Tag extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/com/playus/userservice/domain/user/entity/Tag.java
+++ b/src/main/java/com/playus/userservice/domain/user/entity/Tag.java
@@ -3,6 +3,7 @@ package com.playus.userservice.domain.user.entity;
 import com.playus.userservice.domain.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
 
 @Entity
 @Getter
@@ -10,6 +11,7 @@ import lombok.*;
 @Table(name = "tag", uniqueConstraints = {
         @UniqueConstraint(columnNames = "tag_name", name = "uk_tag_name")
 })
+@SQLDelete(sql = "UPDATE tag SET activated = false WHERE id = ?")
 public class Tag extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/com/playus/userservice/domain/user/entity/User.java
+++ b/src/main/java/com/playus/userservice/domain/user/entity/User.java
@@ -6,14 +6,19 @@ import lombok.*;
 import com.playus.userservice.domain.user.enums.Role;
 import com.playus.userservice.domain.user.enums.Gender;
 import com.playus.userservice.domain.user.enums.AuthProvider;
+import org.hibernate.annotations.SQLDelete;
+
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.Period;
 
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE users SET activated = false WHERE id = ?")
 @Table(name = "users")
+
 public class User extends BaseTimeEntity {
 
     public static final float DEFAULT_SCORE = 0.3f;

--- a/src/main/java/com/playus/userservice/domain/user/entity/User.java
+++ b/src/main/java/com/playus/userservice/domain/user/entity/User.java
@@ -7,6 +7,7 @@ import com.playus.userservice.domain.user.enums.Role;
 import com.playus.userservice.domain.user.enums.Gender;
 import com.playus.userservice.domain.user.enums.AuthProvider;
 import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -17,6 +18,7 @@ import java.time.Period;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE users SET activated = false WHERE id = ?")
+@Where(clause = "activated = true")
 @Table(name = "users")
 
 public class User extends BaseTimeEntity {

--- a/src/main/java/com/playus/userservice/domain/user/entity/User.java
+++ b/src/main/java/com/playus/userservice/domain/user/entity/User.java
@@ -18,7 +18,6 @@ import java.time.Period;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE users SET activated = false WHERE id = ?")
-@Where(clause = "activated = true")
 @Table(name = "users")
 
 public class User extends BaseTimeEntity {

--- a/src/main/java/com/playus/userservice/domain/user/entity/User.java
+++ b/src/main/java/com/playus/userservice/domain/user/entity/User.java
@@ -7,12 +7,9 @@ import com.playus.userservice.domain.user.enums.Role;
 import com.playus.userservice.domain.user.enums.Gender;
 import com.playus.userservice.domain.user.enums.AuthProvider;
 import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.Where;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.Period;
-
 
 @Entity
 @Getter

--- a/src/main/java/com/playus/userservice/domain/user/entity/UserTag.java
+++ b/src/main/java/com/playus/userservice/domain/user/entity/UserTag.java
@@ -4,14 +4,10 @@ package com.playus.userservice.domain.user.entity;
 import com.playus.userservice.domain.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.Where;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@SQLDelete(sql = "UPDATE user_tag SET activated = false WHERE id = ?")
-@Where(clause = "activated = true")
 @Table(name = "user_tag", uniqueConstraints = {
         @UniqueConstraint(columnNames = {"user_id", "tag_id"}, name = "uk_user_tag")
 })

--- a/src/main/java/com/playus/userservice/domain/user/entity/UserTag.java
+++ b/src/main/java/com/playus/userservice/domain/user/entity/UserTag.java
@@ -5,14 +5,16 @@ import com.playus.userservice.domain.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE user_tag SET activated = false WHERE id = ?")
+@Where(clause = "activated = true")
 @Table(name = "user_tag", uniqueConstraints = {
         @UniqueConstraint(columnNames = {"user_id", "tag_id"}, name = "uk_user_tag")
 })
-@SQLDelete(sql = "UPDATE user_tag SET activated = false WHERE id = ?")
 public class UserTag extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/com/playus/userservice/domain/user/entity/UserTag.java
+++ b/src/main/java/com/playus/userservice/domain/user/entity/UserTag.java
@@ -4,6 +4,7 @@ package com.playus.userservice.domain.user.entity;
 import com.playus.userservice.domain.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
 
 @Entity
 @Getter
@@ -11,6 +12,7 @@ import lombok.*;
 @Table(name = "user_tag", uniqueConstraints = {
         @UniqueConstraint(columnNames = {"user_id", "tag_id"}, name = "uk_user_tag")
 })
+@SQLDelete(sql = "UPDATE user_tag SET activated = false WHERE id = ?")
 public class UserTag extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/com/playus/userservice/domain/user/enums/AuthProvider.java
+++ b/src/main/java/com/playus/userservice/domain/user/enums/AuthProvider.java
@@ -1,5 +1,5 @@
 package com.playus.userservice.domain.user.enums;
 
 public enum AuthProvider {
-    KAKAO, NAVER, GOOGLE
+    KAKAO, NAVER
 }

--- a/src/main/java/com/playus/userservice/domain/user/repository/read/FavoriteTeamReadOnlyRepository.java
+++ b/src/main/java/com/playus/userservice/domain/user/repository/read/FavoriteTeamReadOnlyRepository.java
@@ -1,0 +1,12 @@
+package com.playus.userservice.domain.user.repository.read;
+
+import com.playus.userservice.domain.user.document.FavoriteTeamDocument;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import java.util.List;
+
+public interface FavoriteTeamReadOnlyRepository extends MongoRepository<FavoriteTeamDocument, Long> {
+
+    // 사용자별 선호팀 목록 -> displayOrder 순으로 반환
+    List<FavoriteTeamDocument> findAllByUserIdOrderByDisplayOrderAsc(Long userId);
+}

--- a/src/main/java/com/playus/userservice/domain/user/repository/read/UserReadOnlyRepository.java
+++ b/src/main/java/com/playus/userservice/domain/user/repository/read/UserReadOnlyRepository.java
@@ -1,7 +1,7 @@
 package com.playus.userservice.domain.user.repository.read;
 
-import com.playus.userservice.domain.user.entity.User;
+import com.playus.userservice.domain.user.document.UserDocument;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
-public interface UserReadOnlyRepository extends MongoRepository<User, Long> {
+public interface UserReadOnlyRepository extends MongoRepository<UserDocument, Long> {
 }

--- a/src/main/java/com/playus/userservice/domain/user/repository/write/FavoriteTeamRepository.java
+++ b/src/main/java/com/playus/userservice/domain/user/repository/write/FavoriteTeamRepository.java
@@ -10,4 +10,5 @@ public interface FavoriteTeamRepository extends JpaRepository<FavoriteTeam, Long
     Optional<FavoriteTeam> findOneByUser(User user);
     List<FavoriteTeam> findAllByUser(User user);
     void deleteByUser(User user);
+    boolean existsByUserId(Long userId);
 }

--- a/src/main/java/com/playus/userservice/domain/user/repository/write/UserRepository.java
+++ b/src/main/java/com/playus/userservice/domain/user/repository/write/UserRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByIdAndActivatedTrue(Long id);
     Optional<User> findByPhoneNumber(String phoneNumber);
     boolean existsByPhoneNumber(String phoneNumber);
     boolean existsByNickname(String nickname);

--- a/src/main/java/com/playus/userservice/domain/user/service/FavoriteTeamService.java
+++ b/src/main/java/com/playus/userservice/domain/user/service/FavoriteTeamService.java
@@ -31,10 +31,7 @@ public class FavoriteTeamService {
 
         // 사용자 존재 확인
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new ResponseStatusException(
-                        HttpStatus.NOT_FOUND,
-                        "사용자를 찾을 수 없습니다: " + userId
-                ));
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."));
 
         // 팀 ID 검증
         if (Team.fromId(req.teamId()) == null) {
@@ -63,10 +60,7 @@ public class FavoriteTeamService {
     public FavoriteTeamResponse updateFavoriteTeams(Long userId, List<FavoriteTeamRequest> reqs) {
         // 사용자 존재 확인
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new ResponseStatusException(
-                        HttpStatus.NOT_FOUND,
-                        "사용자를 찾을 수 없습니다: " + userId
-                ));
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."));
 
         // 요청 검증 -> 비어 있으면 실패
         if (reqs == null || reqs.isEmpty()) {

--- a/src/main/java/com/playus/userservice/domain/user/service/FavoriteTeamService.java
+++ b/src/main/java/com/playus/userservice/domain/user/service/FavoriteTeamService.java
@@ -30,7 +30,7 @@ public class FavoriteTeamService {
     public FavoriteTeamResponse setFavoriteTeam(Long userId, FavoriteTeamRequest req) {
 
         // 사용자 존재 확인
-        User user = userRepository.findById(userId)
+        User user = userRepository.findByIdAndActivatedTrue(userId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."));
 
         // 팀 ID 검증
@@ -59,7 +59,7 @@ public class FavoriteTeamService {
     @Transactional
     public FavoriteTeamResponse updateFavoriteTeams(Long userId, List<FavoriteTeamRequest> reqs) {
         // 사용자 존재 확인
-        User user = userRepository.findById(userId)
+        User user = userRepository.findByIdAndActivatedTrue(userId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."));
 
         // 요청 검증 -> 비어 있으면 실패

--- a/src/main/java/com/playus/userservice/domain/user/service/ProfileSetupService.java
+++ b/src/main/java/com/playus/userservice/domain/user/service/ProfileSetupService.java
@@ -2,7 +2,10 @@ package com.playus.userservice.domain.user.service;
 
 import com.playus.userservice.domain.user.dto.nickname.NicknameRequest;
 import com.playus.userservice.domain.user.dto.favoriteteam.FavoriteTeamRequest;
+import com.playus.userservice.domain.user.dto.presigned.PresignedUrlForSaveImageRequest;
+import com.playus.userservice.domain.user.dto.presigned.PresignedUrlForSaveImageResponse;
 import com.playus.userservice.domain.user.dto.profilesetup.UserRegisterResponse;
+import com.playus.userservice.global.s3.S3Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,12 +16,14 @@ public class ProfileSetupService {
 
     private final UserService userService;
     private final FavoriteTeamService favoriteTeamService;
+    private final S3Service s3Service;
 
     @Transactional
     public UserRegisterResponse setupProfile(
             Long userId,
             Long favoriteTeamId,
-            String nickname
+            String nickname,
+            String thumbnailURL
     ) {
         // (초기 profile은 displayOrder=1 고정)
         favoriteTeamService.setFavoriteTeam(
@@ -28,6 +33,15 @@ public class ProfileSetupService {
 
         userService.updateNickname(userId, new NicknameRequest(nickname));
 
+        userService.updateImage(userId, thumbnailURL);
+
         return new UserRegisterResponse(true, "프로필이 정상적으로 설정되었습니다.");
+    }
+
+    public PresignedUrlForSaveImageResponse generatePresignedUrlForSaveImage(
+            PresignedUrlForSaveImageRequest request) {
+
+        String url = s3Service.generatePresignedUrl(request.imageFileName());
+        return new PresignedUrlForSaveImageResponse(url);
     }
 }

--- a/src/main/java/com/playus/userservice/domain/user/service/UserProfileReadService.java
+++ b/src/main/java/com/playus/userservice/domain/user/service/UserProfileReadService.java
@@ -1,0 +1,65 @@
+package com.playus.userservice.domain.user.service;
+
+import com.playus.userservice.domain.user.document.FavoriteTeamDocument;
+import com.playus.userservice.domain.user.document.UserDocument;
+import com.playus.userservice.domain.user.dto.profile.FavoriteTeamDto;
+import com.playus.userservice.domain.user.dto.profile.UserProfileResponse;
+import com.playus.userservice.domain.user.repository.read.FavoriteTeamReadOnlyRepository;
+import com.playus.userservice.domain.user.repository.read.UserReadOnlyRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserProfileReadService {
+
+    private final UserReadOnlyRepository userRepository;
+    private final FavoriteTeamReadOnlyRepository favoriteTeamRepository;
+
+    public UserProfileResponse getProfile(Long userId) {
+
+        UserDocument user = userRepository.findById(userId).orElseThrow(()
+                -> new ResponseStatusException(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."));
+
+        List<FavoriteTeamDto> teams = favoriteTeamRepository
+                .findAllByUserIdOrderByDisplayOrderAsc(userId)
+                .stream()
+                .map(this::toDto)
+                .collect(toList());
+
+        return toResponse(user, teams);
+    }
+
+
+    private FavoriteTeamDto toDto(FavoriteTeamDocument doc) {
+        return FavoriteTeamDto.builder()
+                .teamId(doc.getTeamId())
+                .displayOrder(doc.getDisplayOrder())
+                .build();
+    }
+
+    private UserProfileResponse toResponse(UserDocument user, List<FavoriteTeamDto> teams) {
+        return UserProfileResponse.builder()
+                .id(user.getId())
+                .nickname(user.getNickname())
+                .phoneNumber(user.getPhoneNumber())
+                .birth(user.getBirth())
+                .gender(user.getGender())
+                .role(user.getRole())
+                .authProvider(user.getAuthProvider())
+                .activated(user.isActivated())
+                .thumbnailURL(user.getThumbnailURL())
+                .userScore(user.getUserScore())
+                .blockOff(user.getBlockOff())
+                .favoriteTeams(teams)
+                .build();
+    }
+}

--- a/src/main/java/com/playus/userservice/domain/user/service/UserService.java
+++ b/src/main/java/com/playus/userservice/domain/user/service/UserService.java
@@ -26,7 +26,7 @@ public class UserService {
     public NicknameResponse updateNickname(Long userId, NicknameRequest req) {
 
         // 사용자 조회
-        User user = userRepository.findById(userId)
+        User user = userRepository.findByIdAndActivatedTrue(userId)
                 .orElseThrow(() -> new ResponseStatusException(
                         HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."));
 
@@ -44,7 +44,7 @@ public class UserService {
 
     @Transactional
     public void updateImage(Long userId, String thumbnailURL) {
-        User user = userRepository.findById(userId)
+        User user = userRepository.findByIdAndActivatedTrue(userId)
                 .orElseThrow(() ->
                     new ResponseStatusException(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."));
         user.updateImage(thumbnailURL);
@@ -53,15 +53,13 @@ public class UserService {
     @Transactional
     public UserWithdrawResponse withdraw(Long userId, HttpServletRequest req, HttpServletResponse res) {
 
-        User user = userRepository.findById(userId)
+        User user = userRepository.findByIdAndActivatedTrue(userId)
                 .orElseThrow(() ->
                         new ResponseStatusException(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."));
 
-        if (!user.isActivated()) {
-            throw new ResponseStatusException(HttpStatus.CONFLICT, "이미 탈퇴된 사용자입니다.");
-        }
 
-        user.withdrawAccount(); // activated = false 로 변경
+
+        userRepository.delete(user);
 
         authService.logout(req, res);
 

--- a/src/main/java/com/playus/userservice/domain/user/service/UserService.java
+++ b/src/main/java/com/playus/userservice/domain/user/service/UserService.java
@@ -59,7 +59,7 @@ public class UserService {
 
 
 
-        userRepository.delete(user);
+        user.withdrawAccount();   // activated = false
 
         authService.logout(req, res);
 

--- a/src/main/java/com/playus/userservice/domain/user/service/UserService.java
+++ b/src/main/java/com/playus/userservice/domain/user/service/UserService.java
@@ -5,6 +5,7 @@ import com.playus.userservice.domain.user.dto.nickname.NicknameResponse;
 import com.playus.userservice.domain.user.entity.User;
 import com.playus.userservice.domain.user.repository.write.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.crossstore.ChangeSetPersister;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
@@ -34,5 +35,13 @@ public class UserService {
         }
         user.updateNickname(newNickname);
         return new NicknameResponse(true, "닉네임이 성공적으로 변경되었습니다.");
+    }
+
+    @Transactional
+    public void updateImage(Long userId, String thumbnailURL) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() ->
+                    new ResponseStatusException(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."));
+        user.updateImage(thumbnailURL);
     }
 }

--- a/src/main/java/com/playus/userservice/domain/user/service/UserService.java
+++ b/src/main/java/com/playus/userservice/domain/user/service/UserService.java
@@ -55,15 +55,14 @@ public class UserService {
 
         User user = userRepository.findById(userId)
                 .orElseThrow(() ->
-                        new ResponseStatusException(HttpStatus.NOT_FOUND, "USER_NOT_FOUND"));
+                        new ResponseStatusException(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."));
 
         if (!user.isActivated()) {
-            throw new ResponseStatusException(HttpStatus.CONFLICT, "ALREADY_WITHDRAWN");
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "이미 탈퇴된 사용자입니다.");
         }
 
-        user.withdrawAccount();          // activated = false
+        user.withdrawAccount(); // activated = false 로 변경
 
-        // OAuth 토큰 무효화 (재사용 방지)
         authService.logout(req, res);
 
         return new UserWithdrawResponse(true, "회원 탈퇴가 완료되었습니다.");

--- a/src/main/java/com/playus/userservice/domain/user/specification/FavoriteTeamControllerSpecification.java
+++ b/src/main/java/com/playus/userservice/domain/user/specification/FavoriteTeamControllerSpecification.java
@@ -41,11 +41,11 @@ public interface FavoriteTeamControllerSpecification {
                             examples = @ExampleObject(
                                     name  = "선호 팀 등록/수정 요청 예시",
                                     value = """
-                      {
-                        "teamId": 7,
-                        "displayOrder": 1
-                      }
-                      """
+                                    {
+                                        "teamId": 7,
+                                        "displayOrder": 1
+                                    }
+                                    """
                             )
                     )
             )
@@ -57,12 +57,12 @@ public interface FavoriteTeamControllerSpecification {
                             mediaType = APPLICATION_JSON_VALUE,
                             examples = @ExampleObject(
                                     value = """
-                      {
-                        "success": true,
-                        "message": "선호 팀이 정상적으로 등록되었습니다.",
-                        "created": true
-                      }
-                      """
+                                        {
+                                            "success": true,
+                                            "message": "선호 팀이 정상적으로 등록되었습니다.",
+                                            "created": true
+                                        }
+                                        """
                             )
                     )
             ),
@@ -72,12 +72,12 @@ public interface FavoriteTeamControllerSpecification {
                             mediaType = APPLICATION_JSON_VALUE,
                             examples = @ExampleObject(
                                     value = """
-                      {
-                        "success": true,
-                        "message": "선호 팀이 정상적으로 변경되었습니다.",
-                        "created": false
-                      }
-                      """
+                                        {
+                                            "success": true,
+                                            "message": "선호 팀이 정상적으로 변경되었습니다.",
+                                            "created": false
+                                        }
+                                        """
                             )
                     )
             ),
@@ -87,12 +87,12 @@ public interface FavoriteTeamControllerSpecification {
                             mediaType = APPLICATION_JSON_VALUE,
                             examples = @ExampleObject(
                                     value = """
-                      {
-                        "code": 400,
-                        "status": "BAD_REQUEST",
-                        "message": "teamId 필드는 필수입니다."
-                      }
-                      """
+                                    {
+                                        "code": 400,
+                                        "status": "BAD_REQUEST",
+                                        "message": "teamId 필드는 필수입니다."
+                                    }
+                                    """
                             )
                     )
             ),
@@ -102,12 +102,12 @@ public interface FavoriteTeamControllerSpecification {
                             mediaType = APPLICATION_JSON_VALUE,
                             examples = @ExampleObject(
                                     value = """
-                      {
-                        "code": 401,
-                        "status": "UNAUTHORIZED",
-                        "message": "유효하지 않은 토큰입니다."
-                      }
-                      """
+                                    {
+                                        "code": 401,
+                                        "status": "UNAUTHORIZED",
+                                        "message": "유효하지 않은 토큰입니다."
+                                    }
+                                    """
                             )
                     )
             ),
@@ -117,12 +117,12 @@ public interface FavoriteTeamControllerSpecification {
                             mediaType = APPLICATION_JSON_VALUE,
                             examples = @ExampleObject(
                                     value = """
-                      {
-                        "code": 500,
-                        "status": "INTERNAL_SERVER_ERROR",
-                        "message": "서버 내부 오류가 발생했습니다. 관리자에게 문의해 주세요."
-                      }
-                      """
+                                    {
+                                        "code": 500,
+                                        "status": "INTERNAL_SERVER_ERROR",
+                                        "message": "서버 내부 오류가 발생했습니다. 관리자에게 문의해 주세요."
+                                    }
+                                    """
                             )
                     )
             )
@@ -150,11 +150,11 @@ public interface FavoriteTeamControllerSpecification {
                             examples = @ExampleObject(
                                     name  = "선호 팀 일괄 변경 요청 예시",
                                     value = """
-                      [
-                        { "teamId": 7, "displayOrder": 1 },
-                        { "teamId": 8, "displayOrder": 2 }
-                      ]
-                      """
+                                        [
+                                            { "teamId": 7, "displayOrder": 1 },
+                                            { "teamId": 8, "displayOrder": 2 }
+                                        ]
+                                        """
                             )
                     )
             )
@@ -166,12 +166,12 @@ public interface FavoriteTeamControllerSpecification {
                             mediaType = APPLICATION_JSON_VALUE,
                             examples = @ExampleObject(
                                     value = """
-                      {
-                        "success": true,
-                        "message": "선호 팀이 정상적으로 업데이트되었습니다.",
-                        "created": false
-                      }
-                      """
+                                {
+                                    "success": true,
+                                    "message": "선호 팀이 정상적으로 업데이트되었습니다.",
+                                    "created": false
+                                }
+                                """
                             )
                     )
             ),
@@ -181,12 +181,12 @@ public interface FavoriteTeamControllerSpecification {
                             mediaType = APPLICATION_JSON_VALUE,
                             examples = @ExampleObject(
                                     value = """
-                      {
-                        "code": 400,
-                        "status": "BAD_REQUEST",
-                        "message": "requests 필드는 필수입니다."
-                      }
-                      """
+                                    {
+                                        "code": 400,
+                                        "status": "BAD_REQUEST",
+                                        "message": "requests 필드는 필수입니다."
+                                    }
+                                    """
                             )
                     )
             ),
@@ -196,12 +196,12 @@ public interface FavoriteTeamControllerSpecification {
                             mediaType = APPLICATION_JSON_VALUE,
                             examples = @ExampleObject(
                                     value = """
-                      {
-                        "code": 401,
-                        "status": "UNAUTHORIZED",
-                        "message": "유효하지 않은 토큰입니다."
-                      }
-                      """
+                                    {
+                                        "code": 401,
+                                        "status": "UNAUTHORIZED",
+                                        "message": "유효하지 않은 토큰입니다."
+                                    }
+                                    """
                             )
                     )
             ),
@@ -211,12 +211,12 @@ public interface FavoriteTeamControllerSpecification {
                             mediaType = APPLICATION_JSON_VALUE,
                             examples = @ExampleObject(
                                     value = """
-                      {
-                        "code": 404,
-                        "status": "NOT_FOUND",
-                        "message": "존재하지 않는 팀입니다."
-                      }
-                      """
+                                    {
+                                        "code": 404,
+                                        "status": "NOT_FOUND",
+                                        "message": "존재하지 않는 팀입니다."
+                                    }
+                                    """
                             )
                     )
             ),
@@ -226,12 +226,12 @@ public interface FavoriteTeamControllerSpecification {
                             mediaType = APPLICATION_JSON_VALUE,
                             examples = @ExampleObject(
                                     value = """
-                      {
-                        "code": 500,
-                        "status": "INTERNAL_SERVER_ERROR",
-                        "message": "서버 내부 오류가 발생했습니다. 관리자에게 문의해 주세요."
-                      }
-                      """
+                                    {
+                                        "code": 500,
+                                        "status": "INTERNAL_SERVER_ERROR",
+                                        "message": "서버 내부 오류가 발생했습니다. 관리자에게 문의해 주세요."
+                                    }
+                                    """
                             )
                     )
             )

--- a/src/main/java/com/playus/userservice/domain/user/specification/ProfileSetupControllerSpecification.java
+++ b/src/main/java/com/playus/userservice/domain/user/specification/ProfileSetupControllerSpecification.java
@@ -1,6 +1,8 @@
 package com.playus.userservice.domain.user.specification;
 
 import com.playus.userservice.domain.oauth.dto.CustomOAuth2User;
+import com.playus.userservice.domain.user.dto.presigned.PresignedUrlForSaveImageRequest;
+import com.playus.userservice.domain.user.dto.presigned.PresignedUrlForSaveImageResponse;
 import com.playus.userservice.domain.user.dto.profilesetup.UserRegisterRequest;
 import com.playus.userservice.domain.user.dto.profilesetup.UserRegisterResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -49,8 +51,8 @@ public interface ProfileSetupControllerSpecification {
                                     name = "프로필 등록 요청 예시",
                                     value = """
                                             {
-                                              "teamId": 7,
-                                              "nickname": "플레이어"
+                                                "teamId": 7,
+                                                "nickname": "플레이어"
                                             }
                                             """
                             )
@@ -66,8 +68,8 @@ public interface ProfileSetupControllerSpecification {
                                     name = "프로필 등록 응답 예시",
                                     value = """
                                         {
-                                          "success": true,
-                                          "message": "프로필이 정상적으로 설정되었습니다."
+                                            "success": true,
+                                            "message": "프로필이 정상적으로 설정되었습니다."
                                         }
                                         """
                             )
@@ -81,9 +83,9 @@ public interface ProfileSetupControllerSpecification {
                                     name = "잘못된 요청 예시",
                                     value = """
                                         {
-                                          "code": 400,
-                                          "status": "BAD_REQUEST",
-                                          "message": "nickname 필드는 필수입니다."
+                                            "code": 400,
+                                            "status": "BAD_REQUEST",
+                                            "message": "입력값에 대해 검증이 실패했습니다."
                                         }
                                         """
                             )
@@ -97,9 +99,9 @@ public interface ProfileSetupControllerSpecification {
                                     name = "인증 실패 예시",
                                     value = """
                                         {
-                                          "code": 401,
-                                          "status": "UNAUTHORIZED",
-                                          "message": "유효하지 않은 토큰입니다."
+                                            "code": 401,
+                                            "status": "UNAUTHORIZED",
+                                            "message": "유효하지 않은 토큰입니다."
                                         }
                                         """
                             )
@@ -113,9 +115,9 @@ public interface ProfileSetupControllerSpecification {
                                     name = "서버 오류 예시",
                                     value = """
                                         {
-                                          "code": 500,
-                                          "status": "INTERNAL_SERVER_ERROR",
-                                          "message": "서버 내부 오류가 발생했습니다. 관리자에게 문의해 주세요."
+                                            "code": 500,
+                                            "status": "INTERNAL_SERVER_ERROR",
+                                            "message": "서버 내부 오류가 발생했습니다. 관리자에게 문의해 주세요."
                                         }
                                         """
                             )
@@ -127,4 +129,61 @@ public interface ProfileSetupControllerSpecification {
             CustomOAuth2User principal,
             @Valid UserRegisterRequest request
     );
+
+    @Operation(
+            summary = "이미지 업로드용 Presigned URL 생성",
+            description = "클라이언트가 S3에 이미지를 업로드할 수 있도록 Presigned URL을 반환합니다.",
+            requestBody = @RequestBody(
+                    required = true,
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    name = "Presigned URL 요청 예시",
+                                    value = """
+                                        {
+                                            "fileName": "avatar.png",
+                                            "contentType": "image/png"
+                                        }
+                                        """
+                            )
+                    )
+            )
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200", description = "URL 생성 성공",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    name = "Presigned URL 응답 예시",
+                                    value = """
+                                        {
+                                            "url": "https://bucket.s3.amazonaws.com/avatar.png?X-Amz-Algorithm=...",
+                                            "key": "avatars/avatar.png"
+                                        }
+                                        """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400", description = "입력값 검증 실패",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    name = "잘못된 요청 예시",
+                                    value = """
+                                        {
+                                            "code": 400,
+                                            "status": "BAD_REQUEST",
+                                            "message": "fileName 필드는 필수입니다."
+                                        }
+                                        """
+                            )
+                    )
+            )
+    })
+    PresignedUrlForSaveImageResponse generatePresignedUrlForSaveImage(
+            @Valid PresignedUrlForSaveImageRequest request
+    );
+
 }

--- a/src/main/java/com/playus/userservice/domain/user/specification/UserControllerSpecification.java
+++ b/src/main/java/com/playus/userservice/domain/user/specification/UserControllerSpecification.java
@@ -2,6 +2,7 @@ package com.playus.userservice.domain.user.specification;
 
 
 import com.playus.userservice.domain.oauth.dto.CustomOAuth2User;
+import com.playus.userservice.domain.user.dto.UserWithdrawResponse;
 import com.playus.userservice.domain.user.dto.nickname.NicknameRequest;
 import com.playus.userservice.domain.user.dto.nickname.NicknameResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -13,6 +14,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.ResponseEntity;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
@@ -40,8 +43,8 @@ public interface UserControllerSpecification {
                             examples = @ExampleObject(
                                     value = """
                         {
-                          "success": true,
-                          "message": "닉네임이 성공적으로 변경되었습니다."
+                            "success": true,
+                            "message": "닉네임이 성공적으로 변경되었습니다."
                         }
                         """
                             )
@@ -54,9 +57,9 @@ public interface UserControllerSpecification {
                             examples = @ExampleObject(
                                     value = """
                         {
-                          "code": 400,
-                          "status": "BAD_REQUEST",
-                          "message": "nickname 필드는 필수입니다."
+                            "code": 400,
+                            "status": "BAD_REQUEST",
+                            "message": "nickname 필드는 필수입니다."
                         }
                         """
                             )
@@ -69,9 +72,9 @@ public interface UserControllerSpecification {
                             examples = @ExampleObject(
                                     value = """
                         {
-                          "code": 401,
-                          "status": "UNAUTHORIZED",
-                          "message": "유효하지 않은 토큰입니다."
+                            "code": 401,
+                            "status": "UNAUTHORIZED",
+                            "message": "유효하지 않은 토큰입니다."
                         }
                         """
                             )
@@ -84,9 +87,9 @@ public interface UserControllerSpecification {
                             examples = @ExampleObject(
                                     value = """
                         {
-                          "code": 404,
-                          "status": "NOT_FOUND",
-                          "message": "사용자를 찾을 수 없습니다."
+                            "code": 404,
+                            "status": "NOT_FOUND",
+                            "message": "사용자를 찾을 수 없습니다."
                         }
                         """
                             )
@@ -99,9 +102,9 @@ public interface UserControllerSpecification {
                             examples = @ExampleObject(
                                     value = """
                         {
-                          "code": 409,
-                          "status": "CONFLICT",
-                          "message": "이미 사용 중인 닉네임입니다."
+                            "code": 409,
+                            "status": "CONFLICT",
+                            "message": "이미 사용 중인 닉네임입니다."
                         }
                         """
                             )
@@ -114,9 +117,9 @@ public interface UserControllerSpecification {
                             examples = @ExampleObject(
                                     value = """
                         {
-                          "code": 500,
-                          "status": "INTERNAL_SERVER_ERROR",
-                          "message": "서버 내부 오류가 발생했습니다. 관리자에게 문의해 주세요."
+                            "code": 500,
+                            "status": "INTERNAL_SERVER_ERROR",
+                            "message": "서버 내부 오류가 발생했습니다. 관리자에게 문의해 주세요."
                         }
                         """
                             )
@@ -126,5 +129,99 @@ public interface UserControllerSpecification {
     ResponseEntity<NicknameResponse> updateNickname(
             @Parameter(hidden = true) CustomOAuth2User principal,
             @Parameter(description = "새 닉네임", required = true) NicknameRequest request
+    );
+
+    @Operation(
+            summary     = "회원 탈퇴",
+            description = "인증된 사용자의 계정을 소프트 삭제(탈퇴) 처리합니다.",
+            security    = @SecurityRequirement(name = "AccessCookie"),
+            parameters  = @Parameter(
+                    name        = "Access",
+                    description = "JWT access token (쿠키)",
+                    in          = ParameterIn.COOKIE,
+                    required    = true,
+                    example     = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+            )
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200", description = "탈퇴 성공",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = """
+                    {
+                        "success": true,
+                        "message": "회원 탈퇴가 완료되었습니다."
+                    }
+                    """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401", description = "인증 실패",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = """
+                    {
+                        "code": 401,
+                        "status": "UNAUTHORIZED",
+                        "message": "유효하지 않은 토큰입니다."
+                    }
+                    """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404", description = "사용자 없음",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = """
+                    {
+                        "code": 404,
+                        "status": "NOT_FOUND",
+                        "message": "USER_NOT_FOUND"
+                    }
+                    """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "409", description = "이미 탈퇴된 사용자",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = """
+                    {
+                        "code": 409,
+                        "status": "CONFLICT",
+                        "message": "ALREADY_WITHDRAWN"
+                    }
+                    """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500", description = "서버 내부 오류",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = """
+                    {
+                        "code": 500,
+                        "status": "INTERNAL_SERVER_ERROR",
+                        "message": "서버 내부 오류가 발생했습니다. 관리자에게 문의해 주세요."
+                    }
+                    """
+                            )
+                    )
+            )
+    })
+    ResponseEntity<UserWithdrawResponse> withdraw(
+            @Parameter(hidden = true) CustomOAuth2User principal,
+            @Parameter(hidden = true) HttpServletRequest request,
+            @Parameter(hidden = true) HttpServletResponse response
     );
 }

--- a/src/main/java/com/playus/userservice/domain/user/specification/UserProfileControllerSpecification.java
+++ b/src/main/java/com/playus/userservice/domain/user/specification/UserProfileControllerSpecification.java
@@ -1,0 +1,111 @@
+package com.playus.userservice.domain.user.specification;
+
+import com.playus.userservice.domain.oauth.dto.CustomOAuth2User;
+import com.playus.userservice.domain.user.dto.profile.UserProfileResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+@Tag(name = "UserProfile", description = "사용자 프로필 조회 API")
+public interface UserProfileControllerSpecification {
+
+    @Operation(
+            summary     = "내 프로필 조회",
+            description = "로그인한 사용자의 기본 정보와 선호 팀 목록을 조회합니다.",
+            security    = @SecurityRequirement(name = "AccessCookie"),
+            parameters  = @Parameter(
+                    name        = "Access",
+                    description = "JWT access token (쿠키)",
+                    in          = ParameterIn.COOKIE,
+                    required    = true,
+                    example     = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+            )
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200", description = "조회 성공",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    name  = "프로필 조회 응답 예시",
+                                    value = """
+                      {
+                        "id": 18,
+                        "nickname": "default_nickname",
+                        "phoneNumber": "+821079070479",
+                        "birth": "2000-04-26",
+                        "gender": "MALE",
+                        "role": "USER",
+                        "authProvider": "NAVER",
+                        "activated": true,
+                        "thumbnailURL": "default.png",
+                        "userScore": 0.3,
+                        "blockOff": null,
+                        "favoriteTeams": [
+                          { "teamId": 8, "displayOrder": 1 },
+                          { "teamId": 1, "displayOrder": 2 }
+                        ]
+                      }
+                      """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401", description = "인증 실패",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = """
+                      {
+                        "code": 401,
+                        "status": "UNAUTHORIZED",
+                        "message": "유효하지 않은 토큰입니다."
+                      }
+                      """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404", description = "사용자를 찾을 수 없음",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = """
+                      {
+                        "code": 404,
+                        "status": "NOT_FOUND",
+                        "message": "사용자를 찾을 수 없습니다."
+                      }
+                      """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500", description = "서버 내부 오류",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = """
+                      {
+                        "code": 500,
+                        "status": "INTERNAL_SERVER_ERROR",
+                        "message": "서버 내부 오류가 발생했습니다. 관리자에게 문의해 주세요."
+                      }
+                      """
+                            )
+                    )
+            )
+    })
+    ResponseEntity<UserProfileResponse> getProfile(
+            @Parameter(hidden = true) CustomOAuth2User principal
+    );
+}

--- a/src/main/java/com/playus/userservice/domain/user/specification/UserProfileControllerSpecification.java
+++ b/src/main/java/com/playus/userservice/domain/user/specification/UserProfileControllerSpecification.java
@@ -38,7 +38,7 @@ public interface UserProfileControllerSpecification {
                             examples = @ExampleObject(
                                     name  = "프로필 조회 응답 예시",
                                     value = """
-                      {
+                    {
                         "id": 18,
                         "nickname": "default_nickname",
                         "phoneNumber": "+821079070479",
@@ -51,11 +51,11 @@ public interface UserProfileControllerSpecification {
                         "userScore": 0.3,
                         "blockOff": null,
                         "favoriteTeams": [
-                          { "teamId": 8, "displayOrder": 1 },
-                          { "teamId": 1, "displayOrder": 2 }
+                            { "teamId": 8, "displayOrder": 1 },
+                            { "teamId": 1, "displayOrder": 2 }
                         ]
-                      }
-                      """
+                    }
+                    """
                             )
                     )
             ),
@@ -65,12 +65,12 @@ public interface UserProfileControllerSpecification {
                             mediaType = APPLICATION_JSON_VALUE,
                             examples = @ExampleObject(
                                     value = """
-                      {
+                    {
                         "code": 401,
                         "status": "UNAUTHORIZED",
                         "message": "유효하지 않은 토큰입니다."
-                      }
-                      """
+                    }
+                    """
                             )
                     )
             ),
@@ -80,12 +80,12 @@ public interface UserProfileControllerSpecification {
                             mediaType = APPLICATION_JSON_VALUE,
                             examples = @ExampleObject(
                                     value = """
-                      {
+                    {
                         "code": 404,
                         "status": "NOT_FOUND",
                         "message": "사용자를 찾을 수 없습니다."
-                      }
-                      """
+                    }
+                    """
                             )
                     )
             ),
@@ -95,12 +95,12 @@ public interface UserProfileControllerSpecification {
                             mediaType = APPLICATION_JSON_VALUE,
                             examples = @ExampleObject(
                                     value = """
-                      {
+                    {
                         "code": 500,
                         "status": "INTERNAL_SERVER_ERROR",
                         "message": "서버 내부 오류가 발생했습니다. 관리자에게 문의해 주세요."
-                      }
-                      """
+                    }
+                    """
                             )
                     )
             )

--- a/src/main/java/com/playus/userservice/global/config/SecurityConfig.java
+++ b/src/main/java/com/playus/userservice/global/config/SecurityConfig.java
@@ -81,13 +81,6 @@ public class SecurityConfig {
                         .failureHandler(customFailureHandler)
                 )
 
-                // JWT Resource Server 설정 추가
-                .oauth2ResourceServer(rs -> rs
-                        .jwt(jwt -> jwt
-                                .decoder(jwtDecoder())
-                        )
-                )
-
                 // 인증/인가
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(WHITELISTED_PATHS)
@@ -99,11 +92,5 @@ public class SecurityConfig {
 
         return http.build();
     }
-
-    @Bean
-    public JwtDecoder jwtDecoder() {
-        return jwtUtil.jwtDecoder();
-    }
-
 
 }

--- a/src/main/java/com/playus/userservice/global/exception/ExceptionAdvice.java
+++ b/src/main/java/com/playus/userservice/global/exception/ExceptionAdvice.java
@@ -5,6 +5,7 @@ import com.playus.userservice.domain.oauth.service.CustomOAuth2UserService;
 import com.playus.userservice.domain.user.controller.FavoriteTeamController;
 import com.playus.userservice.domain.user.controller.ProfileSetupController;
 import com.playus.userservice.domain.user.controller.UserController;
+import com.playus.userservice.domain.user.controller.UserProfileController;
 import com.playus.userservice.global.response.ErrorResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -24,6 +25,7 @@ import org.springframework.web.server.ResponseStatusException;
         CustomOAuth2UserService.class,
         ProfileSetupController.class,
         FavoriteTeamController.class,
+        UserProfileController.class,
         UserController.class
 })
 public class ExceptionAdvice {

--- a/src/main/java/com/playus/userservice/global/jwt/JwtFilter.java
+++ b/src/main/java/com/playus/userservice/global/jwt/JwtFilter.java
@@ -2,6 +2,7 @@ package com.playus.userservice.global.jwt;
 
 import com.playus.userservice.domain.oauth.dto.CustomOAuth2User;
 import com.playus.userservice.domain.user.dto.UserDto;
+import com.playus.userservice.domain.user.enums.Gender;
 import com.playus.userservice.domain.user.enums.Role;
 import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
@@ -61,9 +62,11 @@ public class JwtFilter extends OncePerRequestFilter {
                 if (!jwtUtil.isExpired(token)) {
                     String userId = jwtUtil.getUserId(token);
                     String role = jwtUtil.getRole(token);
+                    int age = jwtUtil.getAge(token);
+                    String gender = jwtUtil.getGender(token);
 
                     CustomOAuth2User principal = new CustomOAuth2User(
-                            UserDto.fromJwt(Long.parseLong(userId), Role.valueOf(role))
+                            UserDto.fromJwt(Long.parseLong(userId), Role.valueOf(role), age, Gender.valueOf(gender))
                     );
                     Authentication auth = new UsernamePasswordAuthenticationToken(
                             principal, null, principal.getAuthorities()

--- a/src/main/java/com/playus/userservice/global/jwt/JwtUtil.java
+++ b/src/main/java/com/playus/userservice/global/jwt/JwtUtil.java
@@ -34,11 +34,13 @@ public class JwtUtil {
     }
 
     //엑세스토큰
-    public String createAccessToken(String userId, String role) {
+    public String createAccessToken(String userId, String role, int age, String gender) {
         return Jwts.builder()
                 .setId(UUID.randomUUID().toString())
                 .setSubject(userId)
                 .claim("role", role)
+                .claim("age", age)
+                .claim("gender", gender)
                 .claim("type", "access")
                 .setIssuedAt(new Date())
                 .setExpiration(new Date(System.currentTimeMillis() + ACCESS_EXPIRE_MS))

--- a/src/main/java/com/playus/userservice/global/jwt/JwtUtil.java
+++ b/src/main/java/com/playus/userservice/global/jwt/JwtUtil.java
@@ -5,9 +5,6 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
-import org.springframework.security.oauth2.jwt.JwtDecoder;
-import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.stereotype.Component;
 import javax.crypto.SecretKey;
 import java.util.Date;
@@ -24,13 +21,6 @@ public class JwtUtil {
     public JwtUtil(@Value("${spring.jwt.secret}") String secret) {
         byte[] byteSecretKey = Decoders.BASE64.decode(secret);
         this.key = Keys.hmacShaKeyFor(byteSecretKey);
-    }
-
-    public JwtDecoder jwtDecoder() {
-        return NimbusJwtDecoder
-                .withSecretKey(key)
-                .macAlgorithm(MacAlgorithm.HS256)
-                .build();
     }
 
     //엑세스토큰

--- a/src/main/java/com/playus/userservice/global/jwt/JwtUtil.java
+++ b/src/main/java/com/playus/userservice/global/jwt/JwtUtil.java
@@ -73,6 +73,14 @@ public class JwtUtil {
         return extractPayload(token).get("role", String.class);
     }
 
+    public int getAge(String token) {
+        return extractPayload(token).get("age", Integer.class);
+    }
+
+    public String getGender(String token) {
+        return extractPayload(token).get("gender", String.class);
+    }
+
     private Claims extractPayload(String token) {
         return Jwts
                 .parserBuilder()

--- a/src/main/java/com/playus/userservice/global/s3/S3Config.java
+++ b/src/main/java/com/playus/userservice/global/s3/S3Config.java
@@ -1,0 +1,54 @@
+package com.playus.userservice.global.s3;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+import java.net.URI;
+
+@Profile("!test")
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.s3.endpoint}")
+    private String endpoint;
+
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .endpointOverride(URI.create(endpoint))
+                .credentialsProvider(
+                        StaticCredentialsProvider.create(
+                                AwsBasicCredentials.create(accessKey, secretKey)
+                        )
+                )
+                .forcePathStyle(true)
+                .region(Region.of("kr-central-2"))
+                .build();
+    }
+
+    @Bean
+    public S3Presigner s3Presigner() {
+        return S3Presigner.builder()
+                .endpointOverride(URI.create(endpoint))
+                .credentialsProvider(
+                        StaticCredentialsProvider.create(
+                                AwsBasicCredentials.create(accessKey, secretKey)
+                        )
+                )
+                .region(Region.of("kr-central-2"))
+                .build();
+    }
+}

--- a/src/main/java/com/playus/userservice/global/s3/S3Service.java
+++ b/src/main/java/com/playus/userservice/global/s3/S3Service.java
@@ -1,0 +1,60 @@
+package com.playus.userservice.global.s3;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+import java.time.Duration;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class S3Service {
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    private final S3Client s3Client;
+    private final S3Presigner s3Presigner;
+
+    // String fileName = imageUrl.substring(imageUrl.lastIndexOf("/") + 1);
+    public void deleteImage(String imageFileName) {
+
+        DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
+                .bucket(bucketName)
+                .key(imageFileName)
+                .build();
+
+        s3Client.deleteObject(deleteObjectRequest);
+
+        log.info("S3에서 이미지 삭제 완료: {}", imageFileName);
+    }
+
+    public String generatePresignedUrl(String imageFileName) {
+
+        PutObjectRequest objectRequest = createPutObjectRequest(imageFileName);
+        PutObjectPresignRequest presignRequest = createPresignedRequest(objectRequest, 10);
+
+        return s3Presigner.presignPutObject(presignRequest).url().toString();
+    }
+
+    private PutObjectRequest createPutObjectRequest(String imageFileName) {
+        return PutObjectRequest.builder()
+                .bucket(bucketName)
+                .key(imageFileName)
+                .build();
+    }
+
+    private static PutObjectPresignRequest createPresignedRequest(PutObjectRequest objectRequest, int minutes) {
+        return PutObjectPresignRequest.builder()
+                .signatureDuration(Duration.ofMinutes(minutes))
+                .putObjectRequest(objectRequest)
+                .build();
+    }
+}

--- a/src/main/java/com/playus/userservice/global/util/AgeUtils.java
+++ b/src/main/java/com/playus/userservice/global/util/AgeUtils.java
@@ -1,0 +1,21 @@
+package com.playus.userservice.global.util;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.Period;
+
+public class AgeUtils {
+
+    // 생년월일로부터 실제 나이를 계산
+    public static int calculateAge(LocalDateTime birthDateTime) {
+        LocalDate birthDate = birthDateTime.toLocalDate();
+        LocalDate today     = LocalDate.now();
+        return Period.between(birthDate, today).getYears();
+    }
+
+    //나이를 10단위로 내림해서 연령대로 반환
+    public static int calculateAgeGroup(LocalDateTime birthDateTime) {
+        int age = calculateAge(birthDateTime);
+        return (age / 10) * 10;
+    }
+}

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -99,7 +99,8 @@ management:
 
 app:
   frontend:
-    success-redirect-uri: http://localhost:3000/PlayUs-FE#/choice-team
+    success-redirect-uri: http://localhost:3000/PlayUs-FE#/choice-team      # 선호팀 없는 신규 유저
+    success-redirect-uri2: http://localhost:3000/PlayUs-FE#/home           # 선호팀이 이미 있는 유저
     fail-redirect-uri: http://localhost:3000/PlayUs-FE#/login?=error
 
 

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -71,6 +71,15 @@ spring:
   jwt:
     secret: ${JWT_SECRET}
 
+cloud:
+  aws:
+    credentials:
+      access-key: ${STORAGE_ACCESS_KEY}
+      secret-key: ${STORAGE_SECRET_KEY}
+    s3:
+      bucket : ${BUCKET_NAME}
+      endpoint : ${BUCKET_ENDPOINT}
+
 management:
   health:
     redis:

--- a/src/main/resources/application-test.yaml
+++ b/src/main/resources/application-test.yaml
@@ -60,4 +60,5 @@ logging:
 app:
   frontend:
     success-redirect-uri: http://localhost:3000/PlayUs-FE#/choice-team
+    success-redirect-uri2: http://localhost:3000/PlayUs-FE#/home
     fail-redirect-uri: http://localhost:3000/PlayUs-FE#/login?=error

--- a/src/test/java/com/playus/userservice/ControllerTestSupport.java
+++ b/src/test/java/com/playus/userservice/ControllerTestSupport.java
@@ -13,7 +13,6 @@ import com.playus.userservice.global.exception.ExceptionAdvice;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;

--- a/src/test/java/com/playus/userservice/ControllerTestSupport.java
+++ b/src/test/java/com/playus/userservice/ControllerTestSupport.java
@@ -4,13 +4,16 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.playus.userservice.domain.user.controller.FavoriteTeamController;
 import com.playus.userservice.domain.user.controller.ProfileSetupController;
 import com.playus.userservice.domain.user.controller.UserController;
+import com.playus.userservice.domain.user.controller.UserProfileController;
 import com.playus.userservice.domain.user.service.FavoriteTeamService;
 import com.playus.userservice.domain.user.service.ProfileSetupService;
+import com.playus.userservice.domain.user.service.UserProfileReadService;
 import com.playus.userservice.domain.user.service.UserService;
 import com.playus.userservice.global.exception.ExceptionAdvice;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -29,7 +32,8 @@ import org.springframework.data.redis.core.RedisTemplate;
 @WebMvcTest(controllers = {
         ProfileSetupController.class,
         FavoriteTeamController.class,
-        UserController.class
+        UserController.class,
+        UserProfileController.class
 })
 @Import({ControllerTestSupport.TestSecurityConfig.class, ExceptionAdvice.class})
 public abstract class ControllerTestSupport {
@@ -49,6 +53,9 @@ public abstract class ControllerTestSupport {
 
     @MockitoBean
     protected UserService userService;
+
+    @MockitoBean
+    protected UserProfileReadService userProfileReadService;
 
     @MockitoBean
     protected JwtUtil jwtUtil;

--- a/src/test/java/com/playus/userservice/IntegrationTestSupport.java
+++ b/src/test/java/com/playus/userservice/IntegrationTestSupport.java
@@ -1,10 +1,12 @@
 package com.playus.userservice;
 
 
+import com.playus.userservice.global.s3.S3Service;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
@@ -26,6 +28,9 @@ public abstract class IntegrationTestSupport extends OpenFeignClientTestSupport 
 
     private static final int REDIS_PORT = 6379;
     private static final int MONGO_PORT = 27017;
+
+    @MockitoBean
+    protected S3Service s3Service;
 
     static {
         mySQL = new MySQLContainer<>(MYSQL_VERSION)

--- a/src/test/java/com/playus/userservice/IntegrationTestSupport.java
+++ b/src/test/java/com/playus/userservice/IntegrationTestSupport.java
@@ -1,6 +1,7 @@
 package com.playus.userservice;
 
 
+import com.playus.userservice.domain.oauth.service.AuthService;
 import com.playus.userservice.global.s3.S3Service;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;

--- a/src/test/java/com/playus/userservice/domain/user/controller/ProfileSetupControllerTest.java
+++ b/src/test/java/com/playus/userservice/domain/user/controller/ProfileSetupControllerTest.java
@@ -2,6 +2,8 @@ package com.playus.userservice.domain.user.controller;
 
 import com.playus.userservice.ControllerTestSupport;
 import com.playus.userservice.domain.oauth.dto.CustomOAuth2User;
+import com.playus.userservice.domain.user.dto.presigned.PresignedUrlForSaveImageRequest;
+import com.playus.userservice.domain.user.dto.presigned.PresignedUrlForSaveImageResponse;
 import com.playus.userservice.domain.user.dto.profilesetup.UserRegisterRequest;
 import com.playus.userservice.domain.user.dto.profilesetup.UserRegisterResponse;
 import com.playus.userservice.domain.user.enums.Role;
@@ -31,10 +33,8 @@ class ProfileSetupControllerTest extends ControllerTestSupport {
     private UsernamePasswordAuthenticationToken token;
 
     @BeforeEach
-    void setUp() {
+    void init() {
         Long userId = 1L;
-
-        // 더미 OAuth2 사용자
         CustomOAuth2User principal = Mockito.mock(CustomOAuth2User.class);
         when(principal.getName()).thenReturn(userId.toString());
 
@@ -42,24 +42,22 @@ class ProfileSetupControllerTest extends ControllerTestSupport {
                 List.of(new SimpleGrantedAuthority(Role.USER.name()));
         doReturn(authorities).when(principal).getAuthorities();
 
-        token = new UsernamePasswordAuthenticationToken(
-                principal, null, authorities
-        );
+        token = new UsernamePasswordAuthenticationToken(principal, null, authorities);
     }
 
-    //Happy-case
+    /* ---------- Happy case ---------- */
 
-    @DisplayName("프로필을 정상적으로 설정할 수 있다.")
+    @DisplayName("프로필(닉네임,팀,썸네일)을 정상 설정한다.")
     @Test
     void setupProfile() throws Exception {
-        // given
-        UserRegisterRequest req  = new UserRegisterRequest(7L, "닉네임");
-        UserRegisterResponse resp = new UserRegisterResponse(true, "프로필이 정상적으로 설정되었습니다.");
+        UserRegisterRequest req  =
+                new UserRegisterRequest(7L, "닉네임", "image.jpg");
+        UserRegisterResponse resp =
+                new UserRegisterResponse(true, "프로필이 정상적으로 설정되었습니다.");
 
-        given(profileSetupService.setupProfile(any(Long.class), any(Long.class), any(String.class)))
+        given(profileSetupService.setupProfile(any(), any(), any(), any()))
                 .willReturn(resp);
 
-        // when // then
         mockMvc.perform(post("/user/register")
                         .content(objectMapper.writeValueAsString(req))
                         .contentType(APPLICATION_JSON)
@@ -70,37 +68,81 @@ class ProfileSetupControllerTest extends ControllerTestSupport {
                 .andExpect(jsonPath("$.message").value("프로필이 정상적으로 설정되었습니다."));
     }
 
-    //Validation : teamId
+    /* ---------- Validation : teamId / nickname / thumbnailURL ---------- */
 
     @DisplayName("favoriteTeam(teamId) 필드는 필수이다.")
     @Test
     void setupProfile_EMPTY_TEAM_ID() throws Exception {
-        UserRegisterRequest req = new UserRegisterRequest(null, "닉네임");
-        assertBadRequestOfUserRegisterRequest(req, "favoriteTeam 필드는 필수입니다.");
+        UserRegisterRequest req =
+                new UserRegisterRequest(null, "닉네임", "image.jpg");
+        assertBadRequest(req, "favoriteTeam 필드는 필수입니다.");
     }
-
-    //Validation : nickname
 
     @DisplayName("nickname 필드는 필수이다.")
     @NullAndEmptySource
     @ParameterizedTest(name = "nickname = \"{0}\"")
-    void setupProfile_BLANK_NICKNAME(String blankNickname) throws Exception {
-        UserRegisterRequest req = new UserRegisterRequest(5L, blankNickname);
-        assertBadRequestOfUserRegisterRequest(req, "nickname 필드는 필수입니다.");
+    void setupProfile_BLANK_NICKNAME(String blank) throws Exception {
+        UserRegisterRequest req =
+                new UserRegisterRequest(5L, blank, "image.jpg");
+        assertBadRequest(req, "nickname 필드는 필수입니다.");
     }
 
-    //공용 검증 함수
+    @DisplayName("thumbnailURL 필드는 필수이다.")
+    @NullAndEmptySource
+    @ParameterizedTest(name = "thumbnailURL = \"{0}\"")
+    void setupProfile_BLANK_URL(String blank) throws Exception {
+        UserRegisterRequest req =
+                new UserRegisterRequest(5L, "닉네임", blank);
+        assertBadRequest(req, "thumbnailURL 필드는 필수입니다.");
+    }
 
-    private void assertBadRequestOfUserRegisterRequest(UserRegisterRequest req, String expectedMsg) throws Exception {
+    /* ---------- Presigned URL ---------- */
 
+    @DisplayName("이미지 저장용 Presigned URL을 발급한다.")
+    @Test
+    void generatePresignedUrl() throws Exception {
+        PresignedUrlForSaveImageRequest  req  =
+                new PresignedUrlForSaveImageRequest("image.jpg");
+        PresignedUrlForSaveImageResponse resp =
+                new PresignedUrlForSaveImageResponse("https://pre-signed");
+
+        given(profileSetupService.generatePresignedUrlForSaveImage(any()))
+                .willReturn(resp);
+
+        mockMvc.perform(post("/user/presigned-url")
+                        .content(objectMapper.writeValueAsString(req))
+                        .contentType(APPLICATION_JSON)
+                        .with(authentication(token)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.presignedUrl").value("https://pre-signed"));
+    }
+
+    @DisplayName("URL 발급 시 이미지 파일명은 필수이다.")
+    @NullAndEmptySource
+    @ParameterizedTest
+    void generatePresignedUrl_BLANK_NAME(String blank) throws Exception {
+        PresignedUrlForSaveImageRequest req =
+                new PresignedUrlForSaveImageRequest(blank);
+
+        mockMvc.perform(post("/user/presigned-url")
+                        .content(objectMapper.writeValueAsString(req))
+                        .contentType(APPLICATION_JSON)
+                        .with(authentication(token)))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("이미지 파일명은 필수입니다!"));
+    }
+
+    /* ---------- 공용 검증 메서드 ---------- */
+
+    private void assertBadRequest(UserRegisterRequest req, String expectedMsg) throws Exception {
         mockMvc.perform(post("/user/register")
                         .content(objectMapper.writeValueAsString(req))
                         .contentType(APPLICATION_JSON)
                         .with(authentication(token)))
                 .andDo(print())
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.code").value("400"))
-                .andExpect(jsonPath("$.status").value("BAD_REQUEST"))
                 .andExpect(jsonPath("$.message").value(expectedMsg));
     }
 }

--- a/src/test/java/com/playus/userservice/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/playus/userservice/domain/user/controller/UserControllerTest.java
@@ -142,35 +142,4 @@ class UserControllerTest extends ControllerTestSupport {
                         .value("회원 탈퇴가 완료되었습니다."));
     }
 
-    @DisplayName("이미 탈퇴된 사용자는 409 Conflict")
-    @Test
-    void withdraw_conflict() throws Exception {
-        willThrow(new ResponseStatusException(HttpStatus.CONFLICT, "ALREADY_WITHDRAWN"))
-                .given(userService).withdraw(eq(1L), any(), any());
-
-        mockMvc.perform(patch("/user/withdraw")
-                        .with(authentication(token))
-                        .contentType(APPLICATION_JSON))
-                .andExpect(status().isConflict())
-                .andExpect(jsonPath("$.code").value("409"))
-                .andExpect(jsonPath("$.status").value("CONFLICT"))
-                .andExpect(jsonPath("$.message")
-                        .value("ALREADY_WITHDRAWN"));
-    }
-
-    @DisplayName("존재하지 않는 사용자는 404 Not Found")
-    @Test
-    void withdraw_notFound() throws Exception {
-        willThrow(new ResponseStatusException(HttpStatus.NOT_FOUND, "USER_NOT_FOUND"))
-                .given(userService).withdraw(eq(1L), any(), any());
-
-        mockMvc.perform(patch("/user/withdraw")
-                        .with(authentication(token))
-                        .contentType(APPLICATION_JSON))
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.code").value("404"))
-                .andExpect(jsonPath("$.status").value("NOT_FOUND"))
-                .andExpect(jsonPath("$.message")
-                        .value("USER_NOT_FOUND"));
-    }
 }

--- a/src/test/java/com/playus/userservice/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/playus/userservice/domain/user/controller/UserControllerTest.java
@@ -2,6 +2,7 @@ package com.playus.userservice.domain.user.controller;
 
 import com.playus.userservice.ControllerTestSupport;
 import com.playus.userservice.domain.oauth.dto.CustomOAuth2User;
+import com.playus.userservice.domain.user.dto.UserWithdrawResponse;
 import com.playus.userservice.domain.user.dto.nickname.NicknameRequest;
 import com.playus.userservice.domain.user.dto.nickname.NicknameResponse;
 import com.playus.userservice.domain.user.enums.Role;
@@ -26,6 +27,7 @@ import static org.mockito.Mockito.when;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 class UserControllerTest extends ControllerTestSupport {
@@ -120,5 +122,55 @@ class UserControllerTest extends ControllerTestSupport {
                 .andExpect(jsonPath("$.status").value("BAD_REQUEST"))
                 .andExpect(jsonPath("$.message")
                         .value("nickname 필드는 필수입니다."));
+    }
+
+    @DisplayName("회원 탈퇴가 정상적으로 처리된다")
+    @Test
+    void withdraw_success() throws Exception {
+        // given
+        var resp = new UserWithdrawResponse(true, "회원 탈퇴가 완료되었습니다.");
+        given(userService.withdraw(eq(1L), any(), any()))
+                .willReturn(resp);
+
+        // when // then
+        mockMvc.perform(patch("/user/withdraw")
+                        .with(authentication(token))
+                        .contentType(APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.message")
+                        .value("회원 탈퇴가 완료되었습니다."));
+    }
+
+    @DisplayName("이미 탈퇴된 사용자는 409 Conflict")
+    @Test
+    void withdraw_conflict() throws Exception {
+        willThrow(new ResponseStatusException(HttpStatus.CONFLICT, "ALREADY_WITHDRAWN"))
+                .given(userService).withdraw(eq(1L), any(), any());
+
+        mockMvc.perform(patch("/user/withdraw")
+                        .with(authentication(token))
+                        .contentType(APPLICATION_JSON))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("409"))
+                .andExpect(jsonPath("$.status").value("CONFLICT"))
+                .andExpect(jsonPath("$.message")
+                        .value("ALREADY_WITHDRAWN"));
+    }
+
+    @DisplayName("존재하지 않는 사용자는 404 Not Found")
+    @Test
+    void withdraw_notFound() throws Exception {
+        willThrow(new ResponseStatusException(HttpStatus.NOT_FOUND, "USER_NOT_FOUND"))
+                .given(userService).withdraw(eq(1L), any(), any());
+
+        mockMvc.perform(patch("/user/withdraw")
+                        .with(authentication(token))
+                        .contentType(APPLICATION_JSON))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("404"))
+                .andExpect(jsonPath("$.status").value("NOT_FOUND"))
+                .andExpect(jsonPath("$.message")
+                        .value("USER_NOT_FOUND"));
     }
 }

--- a/src/test/java/com/playus/userservice/domain/user/controller/UserProfileControllerTest.java
+++ b/src/test/java/com/playus/userservice/domain/user/controller/UserProfileControllerTest.java
@@ -1,0 +1,99 @@
+package com.playus.userservice.domain.user.controller;
+
+import com.playus.userservice.ControllerTestSupport;
+import com.playus.userservice.domain.oauth.dto.CustomOAuth2User;
+import com.playus.userservice.domain.user.dto.profile.FavoriteTeamDto;
+import com.playus.userservice.domain.user.dto.profile.UserProfileResponse;
+import com.playus.userservice.domain.user.enums.Role;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+class UserProfileControllerTest extends ControllerTestSupport {
+
+    private UsernamePasswordAuthenticationToken token;
+
+    @BeforeEach
+    void setUp() {
+        Long userId = 18L;
+
+        // 더미 OAuth2 사용자
+        CustomOAuth2User principal = Mockito.mock(CustomOAuth2User.class);
+        Mockito.when(principal.getName()).thenReturn(userId.toString());
+
+        List<SimpleGrantedAuthority> authorities =
+                List.of(new SimpleGrantedAuthority(Role.USER.name()));
+        Mockito.doReturn(authorities).when(principal).getAuthorities();
+
+        token = new UsernamePasswordAuthenticationToken(principal, null, authorities);
+    }
+
+    @DisplayName("사용자 프로필을 정상적으로 조회할 수 있다.")
+    @Test
+    void getProfile_success() throws Exception {
+        // given
+        var favoriteTeams = List.of(
+                FavoriteTeamDto.builder().teamId(8L).displayOrder(1).build(),
+                FavoriteTeamDto.builder().teamId(1L).displayOrder(2).build()
+        );
+
+        var resp = UserProfileResponse.builder()
+                .id(18L)
+                .nickname("default_nickname")
+                .phoneNumber("+821079070479")
+                .birth(LocalDate.of(2000, 4, 26))
+                .gender(null)
+                .role(Role.USER)
+                .authProvider(null)
+                .activated(true)
+                .thumbnailURL("default.png")
+                .userScore(0.3f)
+                .blockOff(null)
+                .favoriteTeams(favoriteTeams)
+                .build();
+
+        given(userProfileReadService.getProfile(eq(18L))).willReturn(resp);
+
+        // when // then
+        mockMvc.perform(get("/user/profile")
+                        .with(authentication(token))
+                        .contentType(APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(18))
+                .andExpect(jsonPath("$.nickname").value("default_nickname"))
+                .andExpect(jsonPath("$.favoriteTeams").isArray())
+                .andExpect(jsonPath("$.favoriteTeams[0].teamId").value(8))
+                .andExpect(jsonPath("$.favoriteTeams[1].displayOrder").value(2));
+    }
+
+    @DisplayName("사용자를 찾을 수 없으면 404 Not Found")
+    @Test
+    void getProfile_notFound() throws Exception {
+        willThrow(new ResponseStatusException(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."))
+                .given(userProfileReadService).getProfile(eq(18L));
+
+        mockMvc.perform(get("/user/profile")
+                        .with(authentication(token))
+                        .contentType(APPLICATION_JSON))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("404"))
+                .andExpect(jsonPath("$.status").value("NOT_FOUND"))
+                .andExpect(jsonPath("$.message").value("사용자를 찾을 수 없습니다."));
+    }
+}

--- a/src/test/java/com/playus/userservice/domain/user/service/FavoriteTeamServiceTest.java
+++ b/src/test/java/com/playus/userservice/domain/user/service/FavoriteTeamServiceTest.java
@@ -74,7 +74,7 @@ class FavoriteTeamServiceTest extends IntegrationTestSupport {
         assertThat(resp.created()).isTrue();
         assertThat(resp.message()).contains("등록");
 
-        User user = userRepository.findById(userId).get();
+        User user = userRepository.findByIdAndActivatedTrue(userId).get();
         FavoriteTeam saved = favoriteTeamRepository.findOneByUser(user).get();
         assertThat(saved.getTeamId()).isEqualTo(teamId);
         assertThat(saved.getDisplayOrder()).isEqualTo(1);
@@ -149,7 +149,7 @@ class FavoriteTeamServiceTest extends IntegrationTestSupport {
         assertThat(resp.created()).isFalse();
         assertThat(resp.message()).contains("정상적으로 저장");
 
-        User user = userRepository.findById(userId).get();
+        User user = userRepository.findByIdAndActivatedTrue(userId).get();
         List<FavoriteTeam> saved = favoriteTeamRepository.findAllByUser(user);
         assertThat(saved).hasSize(2)
                 .extracting(FavoriteTeam::getDisplayOrder)

--- a/src/test/java/com/playus/userservice/domain/user/service/ProfileSetupServiceTest.java
+++ b/src/test/java/com/playus/userservice/domain/user/service/ProfileSetupServiceTest.java
@@ -62,7 +62,7 @@ class ProfileSetupServiceTest extends IntegrationTestSupport {
 
         // then
         assertThat(resp.success()).isTrue();
-        User updated = userRepository.findById(userId).get();
+        User updated = userRepository.findByIdAndActivatedTrue(userId).get();
         assertThat(updated.getNickname()).isEqualTo(newNick);
         assertThat(updated.getThumbnailURL()).isEqualTo(newUrl);
 
@@ -77,13 +77,13 @@ class ProfileSetupServiceTest extends IntegrationTestSupport {
     void setupProfile_nicknameConflict() {
         // given
         userRepository.save(
-                User.create("dup", "010-0000-0001",
+                User.create("test1", "010-0000-0001",
                         LocalDate.of(1990, 1, 1),
                         Gender.FEMALE, Role.USER,
                         AuthProvider.KAKAO, "http://a.jpg"));
 
         User other = userRepository.save(
-                User.create("other", "010-0000-0002",
+                User.create("test2", "010-0000-0002",
                         LocalDate.of(1991, 2, 2),
                         Gender.MALE, Role.USER,
                         AuthProvider.KAKAO, "http://b.jpg"));
@@ -91,7 +91,7 @@ class ProfileSetupServiceTest extends IntegrationTestSupport {
         // when // then
         assertThatThrownBy(() ->
                 profileSetupService.setupProfile(
-                        other.getId(), Team.LG_TWINS.id(), "dup", "http://c.jpg"))
+                        other.getId(), Team.LG_TWINS.id(), "test1", "http://c.jpg"))
                 .isInstanceOf(ResponseStatusException.class)
                 .satisfies(e -> {
                     ResponseStatusException ex = (ResponseStatusException) e;

--- a/src/test/java/com/playus/userservice/domain/user/service/ProfileSetupServiceTest.java
+++ b/src/test/java/com/playus/userservice/domain/user/service/ProfileSetupServiceTest.java
@@ -1,6 +1,8 @@
 package com.playus.userservice.domain.user.service;
 
 import com.playus.userservice.IntegrationTestSupport;
+import com.playus.userservice.domain.user.dto.presigned.PresignedUrlForSaveImageRequest;
+import com.playus.userservice.domain.user.dto.presigned.PresignedUrlForSaveImageResponse;
 import com.playus.userservice.domain.user.dto.profilesetup.UserRegisterResponse;
 import com.playus.userservice.domain.user.entity.FavoriteTeam;
 import com.playus.userservice.domain.user.entity.User;
@@ -20,6 +22,8 @@ import java.time.LocalDate;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 
 class ProfileSetupServiceTest extends IntegrationTestSupport {
 
@@ -38,77 +42,56 @@ class ProfileSetupServiceTest extends IntegrationTestSupport {
         userRepository.deleteAllInBatch();
     }
 
-    @DisplayName("프로필을(닉네임 + 선호팀) 정상적으로 설정한다")
+    @DisplayName("프로필(닉네임,팀,썸네일)을 정상적으로 설정한다")
     @Test
     void setupProfile_success() {
         // given
         User user = userRepository.save(
-                User.create(
-                        "test1",
-                        "010-1111-2222",
+                User.create("test1", "010-1111-2222",
                         LocalDate.of(1995, 5, 5),
-                        Gender.MALE,
-                        Role.USER,
-                        AuthProvider.KAKAO,
-                        "http://example.com/old.jpg"
-                )
-        );
+                        Gender.MALE, Role.USER,
+                        AuthProvider.KAKAO, "http://old.jpg"));
         Long userId = user.getId();
         Long teamId = Team.NC_DINOS.id();
-        String newNickname = "newNick";
+        String newNick = "newNick";
+        String newUrl  = "http://new.jpg";
 
         // when
-        UserRegisterResponse resp = profileSetupService.setupProfile(userId, teamId, newNickname);
+        UserRegisterResponse resp =
+                profileSetupService.setupProfile(userId, teamId, newNick, newUrl);
 
         // then
         assertThat(resp.success()).isTrue();
-        assertThat(resp.message()).isEqualTo("프로필이 정상적으로 설정되었습니다.");
-
-        // 닉네임 반영
         User updated = userRepository.findById(userId).get();
-        assertThat(updated.getNickname()).isEqualTo(newNickname);
+        assertThat(updated.getNickname()).isEqualTo(newNick);
+        assertThat(updated.getThumbnailURL()).isEqualTo(newUrl);
 
-        // 선호팀 저장
         Optional<FavoriteTeam> ftOpt = favoriteTeamRepository.findOneByUser(updated);
         assertThat(ftOpt).isPresent();
-        FavoriteTeam ft = ftOpt.get();
-        assertThat(ft.getTeamId()).isEqualTo(teamId);
-        assertThat(ft.getDisplayOrder()).isEqualTo(1);
+        assertThat(ftOpt.get().getTeamId()).isEqualTo(teamId);
+        assertThat(ftOpt.get().getDisplayOrder()).isEqualTo(1);
     }
 
-    @DisplayName("이미 사용 중인 닉네임으로 프로필을 설정하면 CONFLICT 예외가 발생한다")
+    @DisplayName("이미 사용 중인 닉네임이면 CONFLICT 예외가 발생한다")
     @Test
     void setupProfile_nicknameConflict() {
         // given
         userRepository.save(
-                User.create(
-                        "test1",
-                        "010-0000-0001",
+                User.create("dup", "010-0000-0001",
                         LocalDate.of(1990, 1, 1),
-                        Gender.FEMALE,
-                        Role.USER,
-                        AuthProvider.KAKAO,
-                        "http://example.com/a.jpg"
-                )
-        );
+                        Gender.FEMALE, Role.USER,
+                        AuthProvider.KAKAO, "http://a.jpg"));
+
         User other = userRepository.save(
-                User.create(
-                        "test2",
-                        "010-0000-0002",
+                User.create("other", "010-0000-0002",
                         LocalDate.of(1991, 2, 2),
-                        Gender.MALE,
-                        Role.USER,
-                        AuthProvider.KAKAO,
-                        "http://example.com/b.jpg"
-                )
-        );
+                        Gender.MALE, Role.USER,
+                        AuthProvider.KAKAO, "http://b.jpg"));
 
-        Long teamId = Team.LG_TWINS.id();
-
-        // when & then
+        // when // then
         assertThatThrownBy(() ->
-                profileSetupService.setupProfile(other.getId(), teamId, "test1")
-        )
+                profileSetupService.setupProfile(
+                        other.getId(), Team.LG_TWINS.id(), "dup", "http://c.jpg"))
                 .isInstanceOf(ResponseStatusException.class)
                 .satisfies(e -> {
                     ResponseStatusException ex = (ResponseStatusException) e;
@@ -116,4 +99,44 @@ class ProfileSetupServiceTest extends IntegrationTestSupport {
                     assertThat(ex.getReason()).isEqualTo("이미 사용 중인 닉네임입니다.");
                 });
     }
+
+    @DisplayName("Presigned URL을 정상 발급한다")
+    @Test
+    void generatePresignedUrl_success() {
+
+        // given
+        String expected = "https://pre-signed-url.com";
+        given(s3Service.generatePresignedUrl("img.jpg")).willReturn(expected);
+
+        // when
+        PresignedUrlForSaveImageResponse resp =
+                profileSetupService.generatePresignedUrlForSaveImage(
+                        new PresignedUrlForSaveImageRequest("img.jpg"));
+
+        // then
+        assertThat(resp.presignedUrl()).isEqualTo(expected);
+        then(s3Service).should().generatePresignedUrl("img.jpg");
+    }
+
+    @DisplayName("존재하지 않는 사용자면 NOT_FOUND 예외가 발생한다")
+    @Test
+    void setupProfile_userNotFound() {
+
+        // given : DB 비어 있음 (userId = 999L)
+        Long ghostId = 999L;
+
+        // when & then
+        assertThatThrownBy(() ->
+                profileSetupService.setupProfile(
+                        ghostId, Team.LG_TWINS.id(), "nick", "http://img.jpg"))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(e -> {
+                    ResponseStatusException ex = (ResponseStatusException) e;
+                    assertThat(ex.getStatusCode())
+                            .isEqualTo(org.springframework.http.HttpStatus.NOT_FOUND);
+                    assertThat(ex.getReason())
+                            .isEqualTo("사용자를 찾을 수 없습니다.");
+                });
+    }
+
 }

--- a/src/test/java/com/playus/userservice/domain/user/service/UserProfileReadServiceTest.java
+++ b/src/test/java/com/playus/userservice/domain/user/service/UserProfileReadServiceTest.java
@@ -1,0 +1,89 @@
+package com.playus.userservice.domain.user.service;
+
+import com.playus.userservice.IntegrationTestSupport;
+import com.playus.userservice.domain.user.document.FavoriteTeamDocument;
+import com.playus.userservice.domain.user.document.UserDocument;
+import com.playus.userservice.domain.user.dto.profile.UserProfileResponse;
+import com.playus.userservice.domain.user.enums.AuthProvider;
+import com.playus.userservice.domain.user.enums.Gender;
+import com.playus.userservice.domain.user.enums.Role;
+import com.playus.userservice.domain.user.repository.read.FavoriteTeamReadOnlyRepository;
+import com.playus.userservice.domain.user.repository.read.UserReadOnlyRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.*;
+
+class UserProfileReadServiceTest extends IntegrationTestSupport {
+
+    @Autowired
+    private UserProfileReadService userProfileReadService;
+
+    @Autowired
+    private UserReadOnlyRepository userRepo;
+
+    @Autowired
+    private FavoriteTeamReadOnlyRepository teamRepo;
+
+    @AfterEach
+    void tearDown() {
+        teamRepo.deleteAll();
+        userRepo.deleteAll();
+    }
+
+    @DisplayName("사용자 + 선호팀 문서를 모두 저장한 뒤 프로필을 정상적으로 조회한다")
+    @Test
+    void getProfile_success() {
+        // given
+        Long userId = 18L;
+
+        UserDocument userDoc = UserDocument.createUserDocument(
+                userId,
+                "default_nickname",
+                "+821079070479",
+                LocalDate.of(2000, 4, 26),
+                Gender.MALE,
+                Role.USER,
+                AuthProvider.NAVER,
+                true,
+                "default.png",
+                0.3f,
+                null
+        );
+        userRepo.save(userDoc);
+
+        //
+        teamRepo.save(FavoriteTeamDocument.createFavoriteTeamDocument(1L, userId, 8L, 1));
+        teamRepo.save(FavoriteTeamDocument.createFavoriteTeamDocument(2L, userId, 1L, 2));
+
+        //when
+        UserProfileResponse result = userProfileReadService.getProfile(userId);
+
+        // then
+        assertThat(result.id()).isEqualTo(userId);
+        assertThat(result.nickname()).isEqualTo("default_nickname");
+        assertThat(result.favoriteTeams())
+                .extracting("teamId", "displayOrder")
+                .containsExactly(
+                        tuple(8L, 1),
+                        tuple(1L, 2)
+                );
+    }
+
+    @DisplayName("사용자 문서가 없으면 404 ResponseStatusException 을 던진다")
+    @Test
+    void getProfile_notFound() {
+        // given
+        Long invalidId = 999L;
+
+        // when // then
+        assertThatThrownBy(() -> userProfileReadService.getProfile(invalidId))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("404 NOT_FOUND");
+    }
+}

--- a/src/test/java/com/playus/userservice/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/playus/userservice/domain/user/service/UserServiceTest.java
@@ -140,4 +140,24 @@ class UserServiceTest extends IntegrationTestSupport {
         User updated = userRepository.findById(user.getId()).get();
         assertThat(updated.getNickname()).isEqualTo("sameName");
     }
+
+    @DisplayName("updateImage()는 썸네일 URL을 정상 반영한다")
+    @Test
+    void updateImage_success() {
+
+        // given
+        User user = userRepository.save(
+                User.create("test3", "010-3333-4444",
+                        LocalDate.of(2000, 3, 3),
+                        Gender.MALE, Role.USER,
+                        AuthProvider.KAKAO, "http://old.jpg"));
+        String newUrl = "http://brand-new.jpg";
+
+        // when
+        userService.updateImage(user.getId(), newUrl);
+
+        // then
+        User refreshed = userRepository.findById(user.getId()).get();
+        assertThat(refreshed.getThumbnailURL()).isEqualTo(newUrl);
+    }
 }

--- a/src/test/java/com/playus/userservice/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/playus/userservice/domain/user/service/UserServiceTest.java
@@ -211,7 +211,7 @@ class UserServiceTest extends IntegrationTestSupport {
         assertThat(resp.success()).isTrue();
         assertThat(resp.message()).isEqualTo("회원 탈퇴가 완료되었습니다.");
 
-        User updated = userRepository.findByIdAndActivatedTrue(userId).get();
+        User updated = userRepository.findById(userId).get();
         assertThat(updated.isActivated()).isFalse();
     }
 

--- a/src/test/java/com/playus/userservice/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/playus/userservice/domain/user/service/UserServiceTest.java
@@ -1,6 +1,8 @@
 package com.playus.userservice.domain.user.service;
 
 import com.playus.userservice.IntegrationTestSupport;
+import com.playus.userservice.domain.oauth.service.AuthService;
+import com.playus.userservice.domain.user.dto.UserWithdrawResponse;
 import com.playus.userservice.domain.user.dto.nickname.NicknameRequest;
 import com.playus.userservice.domain.user.dto.nickname.NicknameResponse;
 import com.playus.userservice.domain.user.entity.User;
@@ -8,15 +10,24 @@ import com.playus.userservice.domain.user.enums.AuthProvider;
 import com.playus.userservice.domain.user.enums.Gender;
 import com.playus.userservice.domain.user.enums.Role;
 import com.playus.userservice.domain.user.repository.write.UserRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.time.LocalDate;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
 
 class UserServiceTest extends IntegrationTestSupport {
 
@@ -159,5 +170,101 @@ class UserServiceTest extends IntegrationTestSupport {
         // then
         User refreshed = userRepository.findById(user.getId()).get();
         assertThat(refreshed.getThumbnailURL()).isEqualTo(newUrl);
+    }
+
+    /**
+     * @SQLDelete(sql = "UPDATE users SET activated = false WHERE id = ?")
+     * @Where(clause = "activated = true") 주석 처리후 실행
+     */
+
+    @DisplayName("회원 탈퇴가 정상적으로 처리된다")
+    @Test
+    void withdraw_success() {
+
+        AuthService authMock = mock(AuthService.class);
+        ReflectionTestUtils.setField(userService, "authService", authMock);
+
+        // logout()이 호출되더라도 예외 없이 통과하도록 스텁
+        doNothing().when(authMock)
+                .logout(any(HttpServletRequest.class), any(HttpServletResponse.class));
+
+        // given
+        User user = userRepository.save(
+                User.create(
+                        "testUser",
+                        "010-1234-0000",
+                        LocalDate.of(1990, 1, 1),
+                        Gender.MALE,
+                        Role.USER,
+                        AuthProvider.KAKAO,
+                        "http://example.com/thumb.jpg"
+                )
+        );
+        Long userId = user.getId();
+
+        // when
+        HttpServletRequest req = new MockHttpServletRequest();
+        HttpServletResponse res = new MockHttpServletResponse();
+        UserWithdrawResponse resp = userService.withdraw(userId, req, res);
+
+        // then
+        assertThat(resp.success()).isTrue();
+        assertThat(resp.message()).isEqualTo("회원 탈퇴가 완료되었습니다.");
+
+        User updated = userRepository.findById(userId).get();
+        assertThat(updated.isActivated()).isFalse();
+    }
+
+    @DisplayName("이미 탈퇴된 사용자는 409 Conflict 발생")
+    @Test
+    void withdraw_conflict() {
+        // given -> 이미 비활성 상태로 저장
+        User user = userRepository.save(
+                User.create(
+                        "testUser",
+                        "010-1234-0001",
+                        LocalDate.of(1991, 2, 2),
+                        Gender.FEMALE,
+                        Role.USER,
+                        AuthProvider.KAKAO,
+                        "http://example.com/thumb2.jpg"
+                )
+        );
+        user.withdrawAccount();
+        userRepository.save(user);
+        Long userId = user.getId();
+
+        // when
+        HttpServletRequest req = new MockHttpServletRequest();
+        HttpServletResponse res = new MockHttpServletResponse();
+
+        // then
+        assertThatThrownBy(() -> userService.withdraw(userId, req, res))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(ex -> {
+                    ResponseStatusException rsp = (ResponseStatusException) ex;
+                    assertThat(rsp.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+                    assertThat(rsp.getReason()).isEqualTo("ALREADY_WITHDRAWN");
+                });
+    }
+
+    @DisplayName("존재하지 않는 사용자로 탈퇴 시 404 Not Found 발생")
+    @Test
+    void withdraw_userNotFound() {
+        // given
+        Long invalidId = 999L;
+
+        // when
+        HttpServletRequest req = new MockHttpServletRequest();
+        HttpServletResponse res = new MockHttpServletResponse();
+
+        // then
+        assertThatThrownBy(() -> userService.withdraw(invalidId, req, res))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(ex -> {
+                    ResponseStatusException rsp = (ResponseStatusException) ex;
+                    assertThat(rsp.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+                    assertThat(rsp.getReason()).isEqualTo("USER_NOT_FOUND");
+                });
     }
 }


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용

회원 탈퇴 기능

	@SQLDelete 어노테이션 추가를 통한 논리 삭제 처리했습니다.
        entity에 
         @SQLDelete(sql = "UPDATE users SET activated = false WHERE id = ?")
         @Where(clause = "activated = true") 이런식으로 soft delete 처리했습니다.
         Hibernate Filter사용하는 방법도 시도는 해봤는데 HibernateConfig  생성후 tx.getSession() 사용도 막히고, 
         Override로 session 객체 자체에서 enableFilter  호출하는 방식도 잘 되지 않아 기존 코드로 돌아왔습니다.

	 기존 authService.logout() 에서는 Refresh 토큰 쿠키를 지우고, Access 토큰은 블랙리스트에만 등록했었는데,
         클라이언트에 남아 있는 Access 쿠키도 바로 만료 시키도록 변경했습니다.

         withdraw 서비스/컨트롤러 구현

테스트 코드 작성

	Swagger 문서에 회원 탈퇴 및 썸네일 관련 스펙 추가

	기존 Swagger 일부 수정


썸네일 기능

	썸네일 업로드·조회용 컨트롤러·서비스·테스트 코드 추가

	Swagger 문서 반영


OAuth & 인증 관련 리팩토링

	헤더 방식 인증에서 사용하던 리소스 서버용 JWT 검증 코드 제거

	액세스 토큰에 연령대(int age), 성별(string gender) Claim 추가

	JwtFilter 및 JwtUtil DTO 전달값 변경


사용자 정보 조회 기능

	조회용 컨트롤러·서비스·문서·테스트 코드 추가

	Swagger 문서 추가



---

## 🔗 관련 이슈
- closes #3

---

## 💡 추가 사항

twp 에서 직관팟 필터 검색을 빠르게 하기위해서
access Token에 연령대와, 성별을 넣어달라는 요청이 있어 Jwtfilter와 JwtUtil 코드에 일부 수정이 있었습니다.

![image](https://github.com/user-attachments/assets/2dc493e5-530a-46a4-9792-aa0d14cc7b85)

![image](https://github.com/user-attachments/assets/5d469309-356d-417c-a95b-88be19d24d0b)

![image](https://github.com/user-attachments/assets/c9e03469-ef07-40f7-8040-3a497869a2ab)

![image](https://github.com/user-attachments/assets/e70b9880-5950-4684-80b7-f25cda21a0fe)

![image](https://github.com/user-attachments/assets/93fc53b6-473e-411c-8c9a-f50980450746)

global/util 패키지에 AgeUtils에서
생년월일(2000-01-01)기반으로 -> 연령대 (10,20,30,40,50...) 를 int 형으로 리턴합니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 사용자 프로필 조회 REST API가 추가되어, 프로필 정보 및 선호 팀 목록을 확인할 수 있습니다.
  - 회원 탈퇴(소프트 딜리트) 기능이 추가되었습니다.
  - 프로필 이미지 업로드를 위한 S3 Presigned URL 발급 기능이 추가되었습니다.
  - 사용자 프로필 등록 시 썸네일 이미지 URL 입력이 필수로 변경되었습니다.
  - JWT 토큰에 사용자 연령대 및 성별 정보가 포함됩니다.

- **버그 수정**
  - 활성화된 사용자만 조회 및 수정이 가능하도록 일부 API 동작이 개선되었습니다.

- **문서화**
  - Swagger/OpenAPI 문서에 프로필 조회, 회원 탈퇴, Presigned URL 발급 등 신규 기능이 반영되었습니다.

- **테스트**
  - 프로필 조회, 회원 탈퇴, 이미지 Presigned URL 발급 등 신규 기능에 대한 단위/통합 테스트가 추가되었습니다.

- **기타**
  - S3 연동 및 AWS 설정이 추가되었습니다.
  - Google 소셜 로그인 지원이 제거되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->