### PR TITLE
CS-337 Fix/개발활경에서 Cookie를 사용불가 오류 수정

### DIFF
--- a/src/main/java/com/playus/userservice/domain/oauth/handler/CustomSuccessHandler.java
+++ b/src/main/java/com/playus/userservice/domain/oauth/handler/CustomSuccessHandler.java
@@ -76,7 +76,7 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
                     .secure(false)                           // 운영환경(HTTPS)에서는 항상 true
                     .path("/")
                     .maxAge(Duration.ofMillis(JwtUtil.REFRESH_EXPIRE_MS))
-                    .sameSite("Lax")
+                    .sameSite("None")
                     .build();
             response.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());
 
@@ -86,7 +86,7 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
                     .secure(false)
                     .path("/")
                     .maxAge(Duration.ofMillis(JwtUtil.ACCESS_EXPIRE_MS))
-                    .sameSite("Lax")
+                    .sameSite("None")
                     .build();
             response.addHeader(HttpHeaders.SET_COOKIE, accessCookie.toString());
 

--- a/src/main/java/com/playus/userservice/domain/oauth/service/AuthService.java
+++ b/src/main/java/com/playus/userservice/domain/oauth/service/AuthService.java
@@ -84,7 +84,7 @@ public class AuthService {
                 .secure(false)   // 운영환경에선 true 로 변경
                 .path("/")
                 .maxAge(0)
-                .sameSite("Lax")
+                .sameSite("None")
                 .build();
         res.addHeader(HttpHeaders.SET_COOKIE, expiredAccess.toString());
 

--- a/src/main/java/com/playus/userservice/domain/oauth/service/TokenService.java
+++ b/src/main/java/com/playus/userservice/domain/oauth/service/TokenService.java
@@ -69,7 +69,7 @@ public class TokenService {
                 .secure(false)  // 운영환경(HTTPS)에서는 항상 true
                 .path("/")
                 .maxAge(Duration.ofMillis(JwtUtil.ACCESS_EXPIRE_MS))
-                .sameSite("Lax")
+                .sameSite("None")
                 .build();
         res.addHeader(HttpHeaders.SET_COOKIE, accessCookie.toString());
     }
@@ -94,7 +94,7 @@ public class TokenService {
         ResponseCookie cookie = ResponseCookie.from(REFRESH_COOKIE, newRefresh)
                 .httpOnly(true)
                 .secure(false)  // 운영환경(HTTPS)에서는 항상 true
-                .sameSite("Lax")
+                .sameSite("None")
                 .path("/")
                 .maxAge(Duration.ofMillis(JwtUtil.REFRESH_EXPIRE_MS))
                 .build();
@@ -114,7 +114,7 @@ public class TokenService {
             ResponseCookie expired = ResponseCookie.from(REFRESH_COOKIE, "")
                     .httpOnly(true)
                     .secure(false)  // 운영환경(HTTPS)에서는 항상 true
-                    .sameSite("Lax")
+                    .sameSite("None")
                     .path("/")
                     .maxAge(Duration.ZERO)
                     .build();


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
sameSite("None")로 설정하여 FE와 BE의 origin이 다를 경우 cookie를 사용하지 못하는 문제를 해결합니다.

---

## 🔗 관련 이슈
- closes #42

---

## 💡 추가 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 리프레시 토큰 및 액세스 토큰의 쿠키 SameSite 속성이 "Lax"에서 "None"으로 변경되어, 크로스 사이트 요청 시 쿠키 동작이 개선되었습니다.
  - 로그아웃 시 액세스 토큰 쿠키 삭제 시에도 SameSite 속성이 "None"으로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->