### PR TITLE
CS-339 Fix/JavaScript Cookie 사용불가 오류 수정

### DIFF
--- a/src/main/java/com/playus/userservice/domain/oauth/handler/CustomSuccessHandler.java
+++ b/src/main/java/com/playus/userservice/domain/oauth/handler/CustomSuccessHandler.java
@@ -72,17 +72,15 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
 
             ResponseCookie refreshCookie = ResponseCookie.from("Refresh", refreshToken)
-                    .httpOnly(true)
                     .secure(false)                           // 운영환경(HTTPS)에서는 항상 true
                     .path("/")
                     .maxAge(Duration.ofMillis(JwtUtil.REFRESH_EXPIRE_MS))
-                    .sameSite("None")
+                    .sameSite("Lax")
                     .build();
             response.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());
 
             // 4) Access Token 쿠키 (HttpOnly, Secure, SameSite)
             ResponseCookie accessCookie = ResponseCookie.from("Access", accessToken)
-                    .httpOnly(true)
                     .secure(false)
                     .path("/")
                     .maxAge(Duration.ofMillis(JwtUtil.ACCESS_EXPIRE_MS))

--- a/src/main/java/com/playus/userservice/domain/oauth/service/AuthService.java
+++ b/src/main/java/com/playus/userservice/domain/oauth/service/AuthService.java
@@ -80,7 +80,6 @@ public class AuthService {
         }
         // 클라이언트 쿠키(Access) 만료 처리
         ResponseCookie expiredAccess = ResponseCookie.from("Access", "")
-                .httpOnly(true)
                 .secure(false)   // 운영환경에선 true 로 변경
                 .path("/")
                 .maxAge(0)

--- a/src/main/java/com/playus/userservice/domain/oauth/service/TokenService.java
+++ b/src/main/java/com/playus/userservice/domain/oauth/service/TokenService.java
@@ -65,7 +65,6 @@ public class TokenService {
 
         // 4) Access 토큰을 HttpOnly 쿠키로 설정
         ResponseCookie accessCookie = ResponseCookie.from("Access", newAccessToken)
-                .httpOnly(true)
                 .secure(false)  // 운영환경(HTTPS)에서는 항상 true
                 .path("/")
                 .maxAge(Duration.ofMillis(JwtUtil.ACCESS_EXPIRE_MS))
@@ -92,7 +91,6 @@ public class TokenService {
                         TimeUnit.MILLISECONDS);
 
         ResponseCookie cookie = ResponseCookie.from(REFRESH_COOKIE, newRefresh)
-                .httpOnly(true)
                 .secure(false)  // 운영환경(HTTPS)에서는 항상 true
                 .sameSite("Lax")
                 .path("/")
@@ -112,7 +110,6 @@ public class TokenService {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "INVALID_TOKEN");
         } finally {
             ResponseCookie expired = ResponseCookie.from(REFRESH_COOKIE, "")
-                    .httpOnly(true)
                     .secure(false)  // 운영환경(HTTPS)에서는 항상 true
                     .sameSite("Lax")
                     .path("/")

--- a/src/main/java/com/playus/userservice/domain/user/controller/UserProfileController.java
+++ b/src/main/java/com/playus/userservice/domain/user/controller/UserProfileController.java
@@ -43,7 +43,7 @@ public class UserProfileController implements UserProfileControllerSpecification
     }
 
     // 다른 사람 프로필 조회 (nickname, profileImageUrl)
-    @GetMapping("/simple-profile/{user-id}")
+    @GetMapping("/api/simple-profile/{user-id}")
     public ResponseEntity<UserInfoResponse> getUserInfo (
             @PathVariable("user-id") Long targetUserId) {
 


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
- [x] `httpOnly(true)` 설정 삭제
- [x]  `/simple-profile/{user-id}` 엔드포인트 수정

---

## 🔗 관련 이슈
- closes #46

---

## 💡 추가 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 인증 및 로그아웃 시 발급되는 쿠키에서 HttpOnly 속성이 제거되어, 쿠키가 클라이언트 측 스크립트에서도 접근 가능하도록 변경되었습니다.
  - Refresh 토큰 쿠키의 SameSite 속성이 "None"에서 "Lax"로 변경되었습니다.

- **리팩터**
  - 사용자 프로필 조회 API의 엔드포인트가 `/simple-profile/{user-id}`에서 `/api/simple-profile/{user-id}`로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->