### PR TITLE
CS-346 Chore/redis cluster로 변경

### DIFF
--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -14,8 +14,14 @@ spring:
         uri: ${SPRING_DATA_MONGODB_READ_URI}
 
     redis:
-      host: ${REDIS_HOST}
-      port: ${REDIS_PORT}
+      cluster:
+        nodes: ${REDIS_CLUSTER_NODES}
+      timeout: 5s
+      lettuce:
+        pool:
+          max-active: 10
+          max-idle: 10
+          min-idle: 1
 
   jpa:
     database: mysql


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
Redis 연결 방식을 기존 단일 노드 방식에서 Redis Cluster 기반 구성으로 변경했습니다!

**✅ 변경 사항**
- `spring.data.redis.host` / `port` 사용 제거 -> `spring.data.redis.cluster.nodes` 설정으로 변경
- Redis 노드 주소는 환경변수 `REDIS_CLUSTER_NODES`를 통해 주입되며, 쿠버네티스 Secret으로 관리
- Lettuce 클라이언트를 통해 Redis Cluster 구조를 자동 인식하고, 키 해시에 따라 각 노드에 분산 요청 처리

---

## 🔗 관련 이슈
- closes #50 

---

## 💡 추가 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Redis 구성이 단일 인스턴스에서 클러스터 환경으로 변경되었습니다.
  - 연결 풀 및 타임아웃 설정이 추가되어 안정성과 성능이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->