### PR TITLE
Cs 362 fix/sse 구독 이후 알림 전송 수정

### DIFF
--- a/src/main/java/com/playus/userservice/domain/notification/dto/response/NotificationResponse.java
+++ b/src/main/java/com/playus/userservice/domain/notification/dto/response/NotificationResponse.java
@@ -14,7 +14,7 @@ public record NotificationResponse(
 	Long partyId,
 	Long actorId,
 	NotificationType type,
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd", timezone = "Asia/Seoul")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd HH:mm", timezone = "Asia/Seoul")
 	LocalDateTime createdAt,
 	boolean isRead
 ) {

--- a/src/main/java/com/playus/userservice/domain/notification/dto/response/NotificationResponse.java
+++ b/src/main/java/com/playus/userservice/domain/notification/dto/response/NotificationResponse.java
@@ -12,6 +12,7 @@ public record NotificationResponse(
 	String content,
 	Long commentId,
 	Long partyId,
+	Long actorId,
 	NotificationType type,
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd", timezone = "Asia/Seoul")
 	LocalDateTime createdAt,
@@ -24,6 +25,7 @@ public record NotificationResponse(
 				entity.getContent(),
 				entity.getCommentId(),
 				entity.getPartyId(),
+				entity.getActorId(),
 				entity.getType(),
 				entity.getCreatedAt(),
 				entity.isRead()

--- a/src/main/java/com/playus/userservice/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/playus/userservice/domain/notification/service/NotificationService.java
@@ -36,6 +36,10 @@ public class NotificationService {
 
 	// SSE 구독 (CONNECT)
 	public SseEmitter subscribe(Long userId, String lastEventId) {
+
+		emitterRepository.deleteAllEmitterStartWithId(userId.toString());
+		emitterRepository.deleteAllEventCacheStartWithId(userId.toString());
+
 		String emitterId = userId + "_" + System.currentTimeMillis();
 		SseEmitter emitter = emitterRepository.save(emitterId, new SseEmitter(DEFAULT_TIMEOUT));
 

--- a/src/main/java/com/playus/userservice/global/config/SecurityConfig.java
+++ b/src/main/java/com/playus/userservice/global/config/SecurityConfig.java
@@ -70,7 +70,7 @@ public class SecurityConfig {
                     @Override
                     public CorsConfiguration getCorsConfiguration(HttpServletRequest req) {
                         CorsConfiguration c = new CorsConfiguration();
-                        c.setAllowedOrigins(ALLOWED_ORIGINS);
+                        c.setAllowedOriginPatterns(Collections.singletonList("*"));
                         c.setAllowedMethods(Collections.singletonList("*"));
                         c.setAllowedHeaders(Collections.singletonList("*"));
                         c.setAllowCredentials(true);

--- a/src/main/java/com/playus/userservice/global/config/SecurityConfig.java
+++ b/src/main/java/com/playus/userservice/global/config/SecurityConfig.java
@@ -51,7 +51,8 @@ public class SecurityConfig {
             "/oauth2/authorization/naver",
             "/login/oauth2/code/naver",
             "/api/v1/auth/reissue",
-            "/api/v1/auth/logout"
+            "/api/v1/auth/logout",
+            "/actuator/**"
     };
 
     @Bean


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
NotificationResponse에
Long actorId 추가
LocalDateTime createdAt (yyyy.MM.dd HH:mm)으로 변경

SSE 구독 시도시
앞선 연결에 실패하고 남아있는 Emitter 삭제하여 log warn 출력 하지않도록 변경
---

## 🔗 관련 이슈
- closes #3

---

## 💡 추가 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 알림 응답에 `actorId` 필드가 추가되어 알림의 주체 정보를 확인할 수 있습니다.

- **버그 수정**
  - 알림 구독 시 기존 SSE 연결 및 캐시가 정상적으로 삭제되어 중복 연결 문제가 방지됩니다.

- **기타**
  - 알림 생성일시의 표시 형식이 "yyyy.MM.dd HH:mm"으로 변경되어 시간과 분까지 확인할 수 있습니다.
  - 보안 설정에서 `/actuator/**` 경로가 허용되고, CORS가 모든 오리진을 지원하도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->