### PR TITLE
refactor: targetUserId -> user-id 로 변경

### DIFF
--- a/src/main/java/com/playus/userservice/domain/user/specification/UserProfileControllerSpecification.java
+++ b/src/main/java/com/playus/userservice/domain/user/specification/UserProfileControllerSpecification.java
@@ -137,11 +137,11 @@ public interface UserProfileControllerSpecification {
                             example     = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
                     ),
                     @Parameter(
-                            name        = "targetUserId",
+                            name        = "user-id",
                             description = "조회할 사용자 ID",
                             in          = ParameterIn.PATH,
                             required    = true,
-                            example     = "99"
+                            example     = "10"
                     )
             }
     )


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용

![image](https://github.com/user-attachments/assets/b74d295b-229e-4447-92e7-bcee0eb4d462)

targetUserId -> user-id 로 변경하여

swagger에서 다른 유저 프로필 조회 파라미터에 id 값 보이지 않는 문제 해결했습니다.

---

## 🔗 관련 이슈
- closes #3

---

## 💡 추가 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **문서화**
  - "다른 사람 프로필 조회" API에서 사용자 ID 경로 파라미터의 이름과 예시 값이 업데이트되었습니다. (이름: "targetUserId" → "user-id", 예시: "99" → "10")

<!-- end of auto-generated comment: release notes by coderabbit.ai -->