### PR TITLE
CS 393 performance/hikaricp 연결 풀 설정

### DIFF
--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -6,24 +6,26 @@ spring:
     name: user-service
 
   datasource:
-    url: ${SPRING_DATASOURCE_URL}
+    url: ${SPRING_DATASOURCE_URL}?useSSL=false&autoReconnect=true&failOverReadOnly=false&maxReconnects=10&socketTimeout=60000&connectTimeout=60000
     username: ${SPRING_DATASOURCE_USERNAME}
     password: ${SPRING_DATASOURCE_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
-    # HikariCP 설정 추가
+    # OCI 프록시 환경 최적화 HikariCP 설정
     hikari:
-      connection-timeout: 20000         # 연결 타임아웃 20초
-      idle-timeout: 300000              # 유휴 연결 타임아웃 5분
-      max-lifetime: 900000              # 최대 연결 수명 15분
-      maximum-pool-size: 10             # 최대 연결 수
-      minimum-idle: 2                   # 최소 유휴 연결 수
-      validation-timeout: 5000          # 연결 검증 타임아웃 5초
-      leak-detection-threshold: 60000   # 연결 누수 감지 60초
+      connection-timeout: 60000          # OCI 네트워크 지연 고려 60초
+      idle-timeout: 60000                # OCI 프록시가 빨리 끊으므로 1분
+      max-lifetime: 180000               # OCI 프록시 정책 고려 3분
+      maximum-pool-size: 3               # 작은 풀 크기 (OCI 동시 연결 제한)
+      minimum-idle: 1                    # 최소한만 유지
+      validation-timeout: 10000          # 네트워크 지연 고려 10초
+      leak-detection-threshold: 30000    # 30초로 단축
+      connection-test-query: "SELECT 1"  # 연결 검증 쿼리
+
 
   data:
     mongodb:
       read:
-        uri: ${SPRING_DATA_MONGODB_READ_URI}
+        uri: ${SPRING_DATA_MONGODB_READ_URI}&connectTimeoutMS=30000&socketTimeoutMS=30000&serverSelectionTimeoutMS=10000&maxIdleTimeMS=60000
 
     redis:
       cluster:
@@ -45,12 +47,17 @@ spring:
       hibernate.format_sql:    true
       hibernate.show_sql:      true
       hibernate.jdbc.time_zone: Asia/Seoul
-      # 배치 처리 성능 개선
-      hibernate.jdbc.batch_size: 20
-      hibernate.order_inserts: true
-      hibernate.order_updates: true
-      # 연결 관련 개선
+
+      # OCI 환경에서 안정성 우선 설정
+      hibernate.jdbc.batch_size: 1     # 배치 비활성화 (안정성 우선)
+      hibernate.order_inserts: false   # OCI 환경에서 순서 보장 비활성화
+      hibernate.order_updates: false
       hibernate.connection.provider_disables_autocommit: true
+      hibernate.connection.autocommit: false
+
+      # OCI 프록시 연결 관리
+      hibernate.connection.acquisition_timeout: 60000
+      hibernate.connection.validation_timeout: 10000
 
   security:
     oauth2:
@@ -129,17 +136,31 @@ resilience4j:
   circuitbreaker:
     configs:
       default:
-        failure-rate-threshold: 50
+        failure-rate-threshold: 60
         slow-call-rate-threshold: 80
-        slow-call-duration-threshold: 10s
+        slow-call-duration-threshold: 15s
         permitted-number-of-calls-in-half-open-state: 3
         max-wait-duration-in-half-open-state: 0s
         sliding-window-type: COUNT_BASED
         sliding-window-size: 10
         minimum-number-of-calls: 10
-        wait-duration-in-open-state: 10s
+        wait-duration-in-open-state: 15s
     instances:
       circuit:
+        base-config: default
+
+  # OCI 환경 Retry 설정 추가
+  retry:
+    configs:
+      default:
+        max-attempts: 5    # OCI 환경에서 재시도 증가
+        wait-duration: 2s
+        retry-exceptions:
+          - java.sql.SQLException
+          - com.mysql.cj.jdbc.exceptions.CommunicationsException
+          - java.net.SocketTimeoutException
+    instances:
+      database:
         base-config: default
 
 sentry:

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -15,7 +15,8 @@ spring:
       connection-timeout: 60000          # OCI 네트워크 지연 고려 60초
       idle-timeout: 60000                # OCI 프록시가 빨리 끊으므로 1분
       max-lifetime: 180000               # OCI 프록시 정책 고려 3분
-      maximum-pool-size: 3               # 작은 풀 크기 (OCI 동시 연결 제한)
+      keepalive-time: 30000
+      maximum-pool-size: 5               # 작은 풀 크기 (OCI 동시 연결 제한)
       minimum-idle: 1                    # 최소한만 유지
       validation-timeout: 10000          # 네트워크 지연 고려 10초
       leak-detection-threshold: 30000    # 30초로 단축

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -1,3 +1,6 @@
+server:
+  forward-headers-strategy: framework  # ALB HTTPS 헤더 인식
+
 spring:
   application:
     name: user-service
@@ -7,6 +10,15 @@ spring:
     username: ${SPRING_DATASOURCE_USERNAME}
     password: ${SPRING_DATASOURCE_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
+    # HikariCP 설정 추가
+    hikari:
+      connection-timeout: 20000         # 연결 타임아웃 20초
+      idle-timeout: 300000              # 유휴 연결 타임아웃 5분
+      max-lifetime: 900000              # 최대 연결 수명 15분
+      maximum-pool-size: 10             # 최대 연결 수
+      minimum-idle: 2                   # 최소 유휴 연결 수
+      validation-timeout: 5000          # 연결 검증 타임아웃 5초
+      leak-detection-threshold: 60000   # 연결 누수 감지 60초
 
   data:
     mongodb:
@@ -28,10 +40,17 @@ spring:
     hibernate:
       ddl-auto: update
     show-sql: true
+    open-in-view: false  # 성능 개선을 위해 추가
     properties:
       hibernate.format_sql:    true
       hibernate.show_sql:      true
       hibernate.jdbc.time_zone: Asia/Seoul
+      # 배치 처리 성능 개선
+      hibernate.jdbc.batch_size: 20
+      hibernate.order_inserts: true
+      hibernate.order_updates: true
+      # 연결 관련 개선
+      hibernate.connection.provider_disables_autocommit: true
 
   security:
     oauth2:


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
- HikariCP 설정 OCI 환경 최적화
  - 연결 수명 3분, 유휴 타임아웃 1분으로 단축
  - 연결 풀 크기 10 → 3개로 감소 (OCI 동시 연결 제한 고려)
  - connection-test-query 추가로 연결 검증 강화

- Hibernate 안정성 우선 설정
  - 배치 처리 비활성화 (batch_size: 1)
  - OCI 환경 연결 관리 최적화

- Resilience4j Circuit Breaker & Retry 추가
  - DB 연결 실패 시 자동 재시도 (최대 5회)
  - SQL 예외 및 통신 오류 대응

---

## 🔗 관련 이슈
- closes #62 

---

## 💡 추가 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Oracle Cloud Infrastructure(OCI) 프록시 환경에 맞춰 애플리케이션 구성 설정을 최적화했습니다.
  - 데이터베이스 및 MongoDB 연결, 타임아웃, 커넥션 풀, 회복력(Resilience4j) 설정 등이 조정되어 안정성과 성능이 향상되었습니다.
  - Sentry 및 기타 구성 항목이 소폭 추가 또는 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->